### PR TITLE
Native and paid messages

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -45,8 +45,8 @@
 
 infobar revealer > box {
   background-image:
-    -gtk-icontheme("dialog-question-symbolic"),
-    linear-gradient(120deg, @BLUEBERRY_500, @GRAPE_500 67%);
+    -gtk-icontheme("dialog-information-symbolic"),
+    linear-gradient(60deg, @BLUEBERRY_500, @GRAPE_500 67%);
   background-size: 16px, cover;
   background-repeat: no-repeat;
   background-position: 9px 1em, center;
@@ -55,6 +55,13 @@ infobar revealer > box {
     inset 0 1px 0 0 alpha(@colorPrimary, 0.3),
     inset 0 -1px 0 0 alpha(#fff, 0.3);
   color: white;
+}
+
+infobar.question revealer > box {
+  background-image:
+    -gtk-icontheme("dialog-question-symbolic"),
+    linear-gradient(60deg, @BLUEBERRY_500, @GRAPE_500 67%);
+  -gtk-icon-palette: error #fff;
 }
 
 infobar.warning revealer > box {
@@ -67,6 +74,23 @@ infobar.warning revealer > box {
 infobar label,
 infobar button {
   color: white;
+}
+
+infobar button {
+  border-color: alpha (#000, 0.3);
+  box-shadow:
+    inset 0 0 0 1px alpha (#fff, 0.05),
+    inset 0 1px 0 0 alpha (#fff, 0.45),
+    inset 0 -1px 0 0 alpha (#fff, 0.15);
+}
+
+infobar button:active {
+  background-color: alpha (#000, 0.05);
+  background-image: none;
+  border-color: alpha (#000, 0.27);
+  box-shadow:
+    inset 0 0 0 1px alpha (#000, 0.05),
+    0 1px 0 0 alpha (#fff, 0.3);
 }
 
 infobar button.flat:not(:active) {

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -6,6 +6,18 @@
       <summary>Ask to be default</summary>
       <description>Whether or not Ephemeral should ask to be the default web browser (if it isn't already)</description>
     </key>
+    <key name="last-native-response" type="x">
+      <!-- int64 min -->
+      <default>-9223372036854775808</default>
+      <summary>Last native response</summary>
+      <description>The last time (Unix timestamp in UTC) the user responded to the notice about running Ephemeral somewhere other than elementary OS</description>
+    </key>
+    <key name="last-paid-response" type="x">
+      <!-- int64 min -->
+      <default>-9223372036854775808</default>
+      <summary>Last paid response</summary>
+      <description>The last time (Unix timestamp in UTC) the user responded to the notice about Ephemeral being a paid app</description>
+    </key>
     <key name="warn-network" type="b">
       <default>true</default>
       <summary>Warn on no network connection</summary>

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,8 @@ executable(
   'src/Widgets/BrowserButton.vala',
   'src/Widgets/DefaultInfoBar.vala',
   'src/Widgets/NetworkInfoBar.vala',
+  'src/Widgets/NativeInfoBar.vala',
+  'src/Widgets/PaidInfoBar.vala',
   'src/Widgets/UrlEntry.vala',
   asresources,
   dependencies: [

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -32,6 +32,7 @@ public class Ephemeral : Gtk.Application {
     };
     // Once a month
     public const int64 NOTICE_SECS = 60 * 60 * 24 * 30;
+    public const string DONATE_URL = "https://cassidyjames.com/pay";
 
     public bool ask_default_for_session = true;
     private bool opening_link = false;
@@ -110,12 +111,32 @@ public class Ephemeral : Gtk.Application {
     }
 
     public bool get_native () {
-        var gtk_settings = Gtk.Settings.get_default ();
+        string os = "";
+        var file = File.new_for_path ("/etc/os-release");
+        try {
+            var map = new Gee.HashMap<string, string> ();
+            var stream = new DataInputStream (file.read ());
+            string line;
+            // Read lines until end of file (null) is reached
+            while ((line = stream.read_line (null)) != null) {
+                var component = line.split ("=", 2);
+                if (component.length == 2) {
+                    map[component[0]] = component[1].replace ("\"", "");
+                }
+            }
 
-        // TODO: Consider checking for other factors as well
+            os = map["ID"];
+        } catch (GLib.Error e) {
+            critical ("Couldn't read /etc/os-release: %s", e.message);
+        }
+
+        string session = Environment.get_variable ("DESKTOP_SESSION");
+        string stylesheet = Gtk.Settings.get_default ().gtk_theme_name;
+
         return (
-            Environment.get_variable ("DESKTOP_SESSION") == "pantheon" &&
-            gtk_settings.gtk_theme_name == "elementary"
+            os == "elementary" &&
+            session == "pantheon" &&
+            stylesheet == "elementary"
         );
     }
 }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -39,7 +39,6 @@ public class Ephemeral : Gtk.Application {
 
     public bool warn_native_for_session = true;
     public bool warn_paid_for_session = true;
-    public bool paid = false;
 
     public Ephemeral () {
         Object (
@@ -62,15 +61,6 @@ public class Ephemeral : Gtk.Application {
         if (!opening_link) {
             var app_window = new MainWindow (this);
             app_window.show_all ();
-        }
-
-        bool paid = false;
-        var appcenter_settings_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.appcenter.settings", false);
-        if (appcenter_settings_schema != null) {
-            if (appcenter_settings_schema.has_key ("paid-apps")) {
-                var appcenter_settings = new GLib.Settings ("io.elementary.appcenter.settings");
-                paid = strv_contains (appcenter_settings.get_strv ("paid-apps"), Ephemeral.instance.application_id);
-            }
         }
 
         var quit_action = new SimpleAction ("quit", null);
@@ -110,7 +100,7 @@ public class Ephemeral : Gtk.Application {
         return app.run (args);
     }
 
-    public bool get_native () {
+    public bool native () {
         string os = "";
         var file = File.new_for_path ("/etc/os-release");
         try {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -38,7 +38,7 @@ public class MainWindow : Gtk.Window {
         Object (
             application: application,
             border_width: 0,
-            icon_name: "com.github.cassidyjames.ephemeral",
+            icon_name: Ephemeral.instance.application_id,
             resizable: true,
             title: "Ephemeral",
             uri: _uri,
@@ -116,6 +116,8 @@ public class MainWindow : Gtk.Window {
 
         header.custom_title = url_entry;
 
+        var paid_info_bar = new PaidInfoBar ();
+        var native_info_bar = new NativeInfoBar ();
         var default_info_bar = new DefaultInfoBar ();
         var network_info_bar = new NetworkInfoBar ();
 
@@ -131,6 +133,8 @@ public class MainWindow : Gtk.Window {
 
         var grid = new Gtk.Grid ();
         grid.orientation = Gtk.Orientation.VERTICAL;
+        grid.add (paid_info_bar);
+        grid.add (native_info_bar);
         grid.add (default_info_bar);
         grid.add (network_info_bar);
         grid.add (stack);
@@ -319,7 +323,7 @@ public class MainWindow : Gtk.Window {
         close ();
     }
 
-    private void new_window (string? uri = null) {
+    public void new_window (string? uri = null) {
         var app_window = new MainWindow (application, uri);
         app_window.show_all ();
     }

--- a/src/Widgets/DefaultInfoBar.vala
+++ b/src/Widgets/DefaultInfoBar.vala
@@ -38,6 +38,7 @@ public class DefaultInfoBar : Gtk.InfoBar {
         var app_info = new GLib.DesktopAppInfo (GLib.Application.get_default ().application_id + ".desktop");
 
         var never_button = new Gtk.Button.with_label ("Never Ask Again");
+        never_button.halign = Gtk.Align.END;
         never_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         get_content_area ().add (default_label);

--- a/src/Widgets/DefaultInfoBar.vala
+++ b/src/Widgets/DefaultInfoBar.vala
@@ -60,6 +60,8 @@ public class DefaultInfoBar : Gtk.InfoBar {
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }
+                    revealed = false;
+                    break;
                 case Gtk.ResponseType.REJECT:
                     settings.set_boolean ("ask-default", false);
                 case Gtk.ResponseType.CLOSE:

--- a/src/Widgets/DefaultInfoBar.vala
+++ b/src/Widgets/DefaultInfoBar.vala
@@ -28,7 +28,7 @@ public class DefaultInfoBar : Gtk.InfoBar {
     }
 
     construct {
-        var settings = new Settings ("com.github.cassidyjames.ephemeral");
+        var settings = new Settings (Ephemeral.instance.application_id);
 
         var default_label = new Gtk.Label ("<b>Make privacy a habit.</b> Set Ephemeral as your default browser?\n<small>You can always change this later in <i>System Settings</i> → <i>Applications</i>.</small>");
         default_label.use_markup = true;

--- a/src/Widgets/NativeInfoBar.vala
+++ b/src/Widgets/NativeInfoBar.vala
@@ -47,7 +47,7 @@ public class NativeInfoBar : Gtk.InfoBar {
         int64 now = new DateTime.now_utc ().to_unix ();
 
         revealed =
-            ! Ephemeral.instance.get_native () &&
+            ! Ephemeral.instance.native () &&
             (settings.get_int64 ("last-native-response") < now - Ephemeral.NOTICE_SECS) &&
             Ephemeral.instance.warn_native_for_session;
 

--- a/src/Widgets/NativeInfoBar.vala
+++ b/src/Widgets/NativeInfoBar.vala
@@ -34,8 +34,15 @@ public class NativeInfoBar : Gtk.InfoBar {
         default_label.use_markup = true;
         default_label.wrap = true;
 
+        var dismiss_button = new Gtk.Button.with_label ("Dismiss");
+        dismiss_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
+        var donate_button = new Gtk.Button.with_label ("Donate…");
+        donate_button.tooltip_text = Ephemeral.DONATE_URL;
+
         get_content_area ().add (default_label);
-        add_button ("Donate…", Gtk.ResponseType.ACCEPT);
+        add_action_widget (dismiss_button, Gtk.ResponseType.REJECT);
+        add_action_widget (donate_button, Gtk.ResponseType.ACCEPT);
 
         int64 now = new DateTime.now_utc ().to_unix ();
 
@@ -48,7 +55,7 @@ public class NativeInfoBar : Gtk.InfoBar {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        Gtk.show_uri (get_screen (), "https://cassidyjames.com/pay", Gtk.get_current_event_time ());
+                        Gtk.show_uri (get_screen (), Ephemeral.DONATE_URL, Gtk.get_current_event_time ());
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }

--- a/src/Widgets/NativeInfoBar.vala
+++ b/src/Widgets/NativeInfoBar.vala
@@ -35,6 +35,7 @@ public class NativeInfoBar : Gtk.InfoBar {
         default_label.wrap = true;
 
         var dismiss_button = new Gtk.Button.with_label ("Dismiss");
+        dismiss_button.halign = Gtk.Align.END;
         dismiss_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var donate_button = new Gtk.Button.with_label ("Donate…");

--- a/src/Widgets/NativeInfoBar.vala
+++ b/src/Widgets/NativeInfoBar.vala
@@ -19,10 +19,10 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class NetworkInfoBar : Gtk.InfoBar {
-    public NetworkInfoBar () {
+public class NativeInfoBar : Gtk.InfoBar {
+    public NativeInfoBar () {
         Object (
-            message_type: Gtk.MessageType.WARNING,
+            message_type: Gtk.MessageType.INFO,
             show_close_button: true
         );
     }
@@ -30,52 +30,39 @@ public class NetworkInfoBar : Gtk.InfoBar {
     construct {
         var settings = new Settings (Ephemeral.instance.application_id);
 
-        var default_label = new Gtk.Label ("<b>Network Not Available.</b> Connect to the Internet to browse the Web.");
+        var default_label = new Gtk.Label ("<b>Ephemeral is a paid app designed for elementary OS.</b> Some features may not work properly when running on another OS or desktop environment.\n<small>Ephemeral is also typically funded by elementary AppCenter purchases. Consider donating if you find value in using Ephemeral on other platforms.</small>");
         default_label.use_markup = true;
         default_label.wrap = true;
 
-        var never_button = new Gtk.Button.with_label ("Never Warn Again");
-        never_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
-
         get_content_area ().add (default_label);
-        add_action_widget (never_button, Gtk.ResponseType.REJECT);
-        add_button ("Network Settings…", Gtk.ResponseType.ACCEPT);
+        add_button ("Donate…", Gtk.ResponseType.ACCEPT);
 
-        try_set_revealed ();
+        int64 now = new DateTime.now_utc ().to_unix ();
+
+        revealed =
+            ! Ephemeral.instance.get_native () &&
+            (settings.get_int64 ("last-native-response") < now - Ephemeral.NOTICE_SECS) &&
+            Ephemeral.instance.warn_native_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        AppInfo.launch_default_for_uri ("settings://network", null);
+                        Gtk.show_uri (get_screen (), "https://cassidyjames.com/pay", Gtk.get_current_event_time ());
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }
-                    break;
                 case Gtk.ResponseType.REJECT:
-                    settings.set_boolean ("warn-network", false);
+                    now = new DateTime.now_utc ().to_unix ();
+                    settings.set_int64 ("last-native-response", now);
                 case Gtk.ResponseType.CLOSE:
+                    Ephemeral.instance.warn_native_for_session = false;
                     revealed = false;
                     break;
                 default:
                     assert_not_reached ();
             }
         });
-
-        var network_monitor = NetworkMonitor.get_default ();
-        network_monitor.network_changed.connect (() => {
-            try_set_revealed ();
-        });
-    }
-
-    private void try_set_revealed (bool? reveal = true) {
-        var settings = new Settings ("com.github.cassidyjames.ephemeral");
-        var network_available = NetworkMonitor.get_default ().get_network_available ();
-
-        revealed =
-            reveal &&
-            settings.get_boolean ("warn-network") &&
-            !network_available;
     }
 }
 

--- a/src/Widgets/NetworkInfoBar.vala
+++ b/src/Widgets/NetworkInfoBar.vala
@@ -35,6 +35,7 @@ public class NetworkInfoBar : Gtk.InfoBar {
         default_label.wrap = true;
 
         var never_button = new Gtk.Button.with_label ("Never Warn Again");
+        never_button.halign = Gtk.Align.END;
         never_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         get_content_area ().add (default_label);

--- a/src/Widgets/PaidInfoBar.vala
+++ b/src/Widgets/PaidInfoBar.vala
@@ -35,6 +35,7 @@ public class PaidInfoBar : Gtk.InfoBar {
         default_label.wrap = true;
 
         var dismiss_button = new Gtk.Button.with_label ("Dismiss");
+        dismiss_button.halign = Gtk.Align.END;
         dismiss_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         get_content_area ().add (default_label);


### PR DESCRIPTION
The behavior, if any, of this PR _has **not**_ been decided on yet. I'm opening it here to put my code somewhere safe and to think about the ramifications. :smile: 

If merged as-is, this PR would:

- **Add a "native" check to Ephemeral.** This would exist to be able to give users a heads up if they've installed Ephemeral from some other unsupported distribution method, as the only supported distribution method is AppCenter on elementary OS. It also gives me a place to show a "Donate" URL since distribution methods other than AppCenter do not allow me to get paid for my work.

- **Add a "paid" check to Ephemeral** if running on elementary OS (requiring the "native" check). This would use the same exact mechanism as AppCenter in order to check if the user has purchased or funded Ephemeral. If not, at most once a month a one-click dismissable message would be visible to users, explaining the Ephemeral is a paid app and that purchasing on AppCenter is how you can support development.

- **Attempt to set the elementary stylesheet.** Since I'm using so many specific elementary stylesheet features, it can look broken in other stylesheets. This PR would try to force the styleseheet at the app level to avoid brokenness.

Any native or paid messages are throttled to show _at most_ once a month. So a user who is happily using Ephemeral for several months either on another platform or for free on elementary OS would still only see any message a handful of times. I am also aware that each of these measures could be easily "defeated," as the source is open and GSettings are user-accessible.