### PR TITLE
Fixed some translations

### DIFF
--- a/po/com.github.cassidyjames.ephemeral.pot
+++ b/po/com.github.cassidyjames.ephemeral.pot
@@ -143,6 +143,10 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
+#: src/MainWindow.vala:77
+msgid "Back"
+msgstr ""
+
 #: src/MainWindow.vala:82
 msgid "Forward"
 msgstr ""
@@ -157,6 +161,10 @@ msgstr ""
 
 #: src/MainWindow.vala:101
 msgid "Erase browsing history"
+msgstr ""
+
+#: src/MainWindow.vala:109
+msgid "Menu"
 msgstr ""
 
 #: src/MainWindow.vala:117

--- a/po/fr.po
+++ b/po/fr.po
@@ -184,6 +184,10 @@ msgstr "WWW;web;navigateur;internet;privé;incognito;focus;temporaire;cookies;"
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
+#: src/MainWindow.vala:77
+msgid "Back"
+msgstr "Retour"
+
 #: src/MainWindow.vala:82
 msgid "Forward"
 msgstr "Suivant"
@@ -199,6 +203,10 @@ msgstr "Arrêter le chargement"
 #: src/MainWindow.vala:101
 msgid "Erase browsing history"
 msgstr "Effacer l'historique de navigation"
+
+#: src/MainWindow.vala:109
+msgid "Menu"
+msgstr "Menu"
 
 #: src/MainWindow.vala:117
 msgid "Zoom out"

--- a/po/fr.po
+++ b/po/fr.po
@@ -132,7 +132,7 @@ msgid ""
 msgstr ""
 "Que faire si vous rencontrez un problème de compatibilité de site en raison "
 "de la prévention du suivi, ou si vous voulez vous connecter à un site en "
-"utilisant les mots de passe enregistrés dans un autre navigateur ?Ephemeral "
+"utilisant les mots de passe enregistrés dans un autre navigateur ? Ephemeral "
 "vous couvre : il vous suffit d'appuyer sur l'icône de votre autre navigateur "
 "dans le menu de supérieur et la page actuelle s'y ouvre."
 
@@ -267,7 +267,7 @@ msgid ""
 "Any dismissed or remembered alerts, warnings, etc. will be displayed again "
 "the next time Ephemeral is opened."
 msgstr ""
-"Toutes les alertes, rappels, avertissements, etc. rejetées ou mémorisées "
+"Toutes les alertes, rappels, avertissements, etc. rejetés ou mémorisés "
 "s'afficheront à nouveau à la prochaine ouverture d'Ephemeral."
 
 #: src/Dialogs/PreferencesDialog.vala:33
@@ -276,7 +276,7 @@ msgstr "En fait non"
 
 #: src/Dialogs/PreferencesDialog.vala:36
 msgid "Reset Preferences"
-msgstr "Réinitialiserles préférences"
+msgstr "Réinitialiser les préférences"
 
 #: src/Views/ErrorView.vala:28
 msgid "Whoops"

--- a/po/fr.po
+++ b/po/fr.po
@@ -186,7 +186,7 @@ msgstr "Nouvelle fenêtre"
 
 #: src/MainWindow.vala:77
 msgid "Back"
-msgstr "Retour"
+msgstr "Précédent"
 
 #: src/MainWindow.vala:82
 msgid "Forward"

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -74,7 +74,7 @@ public class MainWindow : Gtk.Window {
 
         back_button = new Gtk.Button.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         back_button.sensitive = false;
-        back_button.tooltip_text = "Back";
+        back_button.tooltip_text = _("Back");
         back_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Alt>Left"}, back_button.tooltip_text);
 
         forward_button = new Gtk.Button.from_icon_name ("go-next-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
@@ -106,7 +106,7 @@ public class MainWindow : Gtk.Window {
 
         var settings_button = new Gtk.MenuButton ();
         settings_button.image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR);
-        settings_button.tooltip_text = "Menu";
+        settings_button.tooltip_text = _("Menu");
 
         var settings_popover = new Gtk.Popover (settings_button);
         settings_button.popover = settings_popover;


### PR DESCRIPTION
### Changelog

- Fixed some French translations,
- Fixed "Back" and "Menu" strings not translatable in `MainWindow.vala`,
- Added theses missing strings to `com.github.cassidyjames.ephemeral.pot`,
- Added translations in `fr.po`

### Problems

Please update others translations files than `fr.po` from the `com.github.cassidyjames.ephemeral.pot` file to add the missing strings (I don't know how to do it for all the files at the same time).

I found an error when I checked translations at line `42` in `UrlEntry.vala file`:

`secondary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"Return"}, secondary_icon_tooltip_text);`

I think that "Return" isn't the correct string. I saw the French translation in app but it doesn't make sense. Can you check ?