### PR TITLE
Add websites to suggestions

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -86,11 +86,11 @@
 }
 
 .titlebar entry image {
-    color: alpha(@textColorPrimary, 0.75);
+    color: @textColorPrimary;
 }
 
 .titlebar entry image:hover {
-    color: @textColorPrimary;
+    color: alpha(@textColorPrimary, 0.75);
 }
 
 infobar revealer > box {

--- a/data/gschema.xml
+++ b/data/gschema.xml
@@ -11,6 +11,11 @@
       <summary>Close when opening externally</summary>
       <description>Whether or not the current Ephemeral window should be closed when opening a link in an external browser</description>
     </key>
+    <key type="as" name="favorite-websites">
+        <default>[]</default>
+        <summary>User-added favorite websites</summary>
+        <description>List of favorite websites added by the user, i.e. to be used in autocomplete suggestions. Should contain bare hosts (i.e. subdomain.example.com) to be more easily completable by the user.</description>
+    </key>
     <key name="last-native-response" type="x">
       <!-- int64 min -->
       <default>-9223372036854775808</default>

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -24,7 +24,7 @@ public class PreferencesDialog : Granite.MessageDialog {
         Object (
             image_icon: new ThemedIcon ("document-open-recent"),
             primary_text: _("Reset Preferences?"),
-            secondary_text: _("Any dismissed or remembered alerts, warnings, etc. will be displayed again the next time Ephemeral is opened."),
+            secondary_text: _("All favorite websites will be removed. Any dismissed or remembered alerts, warnings, etc. will be displayed again the next time Ephemeral is opened."),
             title: _("Reset Preferences?")
         );
     }

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -57,6 +57,14 @@ public class UrlEntry : Gtk.Entry {
         completion.pack_start (cell, false);
         completion.add_attribute (cell, "text", 1);
 
+        var favorites = Ephemeral.settings.get_value ("favorite-websites");
+        var favorite_iter = new GLib.VariantIter (favorites);
+        string favorite_domain;
+
+        while (favorite_iter.next ("s", out favorite_domain)) {
+            add_suggestion (favorite_domain, null, _("Favorite website"));
+        }
+
         add_suggestion ("247sports.com", "247Sports");
         add_suggestion ("6pm.com", "6pm");
         add_suggestion ("aa.com", "American Airlines");
@@ -535,9 +543,7 @@ public class UrlEntry : Gtk.Entry {
                     activate ();
                 } else {
                     critical ("Pinning not yet persistent.");
-
                     var uri = new Soup.URI (text);
-
                     add_suggestion (uri.get_host (), null, _("Favorite website"));
                 }
             }
@@ -574,7 +580,6 @@ public class UrlEntry : Gtk.Entry {
             secondary_icon_tooltip_text = _("Go");
             secondary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"Return"}, secondary_icon_tooltip_text);
         } else {
-            var uri = new Soup.URI (text);
             critical ("Doesn't check if already favorited or not.");
 
             secondary_icon_name = "non-starred-symbolic";

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -612,7 +612,7 @@ public class UrlEntry : Gtk.Entry {
 
             if (domain in current_favorites) {
                 debug ("%s is a favorite, showing filled star.", domain);
-                secondary_icon_name = "starred-symbolic";
+                secondary_icon_name = "starred";
                 secondary_icon_tooltip_text = _("Remove Website from Suggestions");
             } else {
                 debug ("%s is not a favorite, showing empty star.", domain);

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -43,8 +43,8 @@ public class UrlEntry : Gtk.Entry {
         primary_icon_tooltip_text = _("Enter a URL or search term");
         primary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, primary_icon_tooltip_text);
 
-        var favorites = Ephemeral.settings.get_strv ("favorite-websites");
-        reset_suggestions (favorites);
+        var initial_favorites = Ephemeral.settings.get_strv ("favorite-websites");
+        reset_suggestions (initial_favorites);
         set_secondary_icon ();
 
         activate.connect (() => {
@@ -163,7 +163,8 @@ public class UrlEntry : Gtk.Entry {
         completion.pack_start (cell, false);
         completion.add_attribute (cell, "text", 1);
 
-        foreach (var favorite in favorites) {
+        var current_favorites = Ephemeral.settings.get_strv ("favorite-websites");
+        foreach (var favorite in current_favorites) {
             add_suggestion (favorite, null, _("Favorite website"));
         }
 
@@ -606,11 +607,11 @@ public class UrlEntry : Gtk.Entry {
             secondary_icon_tooltip_text = _("Go");
             secondary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"Return"}, secondary_icon_tooltip_text);
         } else {
-            var favorites = Ephemeral.settings.get_strv ("favorite-websites");
+            var current_favorites = Ephemeral.settings.get_strv ("favorite-websites");
             var uri = new Soup.URI (text);
             string domain = uri.get_host ();
 
-            if (domain in favorites) {
+            if (domain in current_favorites) {
                 debug ("%s is a favorite, showing filled star.", domain);
                 secondary_icon_name = "starred-symbolic";
                 secondary_icon_tooltip_text = _("Remove Website from Suggestions");

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -21,7 +21,7 @@
 
 public class UrlEntry : Gtk.Entry {
     private Gtk.ListStore list_store { get; set; }
-    // private Gtk.TreeIter iter { get; set; }
+    private Gtk.TreeIter iter { get; set; }
 
     public WebKit.WebView web_view { get; construct set; }
 
@@ -163,8 +163,7 @@ public class UrlEntry : Gtk.Entry {
         completion.pack_start (cell, false);
         completion.add_attribute (cell, "text", 1);
 
-        var current_favorites = Ephemeral.settings.get_strv ("favorite-websites");
-        foreach (var favorite in current_favorites) {
+        foreach (var favorite in favorites) {
             add_suggestion (favorite, null, _("Favorite website"));
         }
 


### PR DESCRIPTION
Fixes #72 with a "Add Website to Suggestions" item.

- [x] Persist to GSettings
- [x] Load from GSettings
- [x] Prevent duplicates by correctly marking added suggestions as "starred"
- [x] Mention suggestions in Reset Preferences dialog
- [ ] ~Implement Ctrl+D shortcut~ #132
- [x] Remove from suggestions when removing from GSettings
- [ ] ~Treat built-in suggestions as favorites?~ #133
- [x] Improve contrast on entry icons
- [x] Fix errors around invalid URLs being passed to Soup
- [x] Fix critical `gtk_list_store_clear: assertion 'GTK_IS_LIST_STORE (list_store)' failed`
- [x] Use `web_view.get_uri ()` instead of URL entry text