### PR TITLE
Use Dazzle.SuggestionEntry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,14 @@ Development is targeted at [elementary OS] Juno. If you want to hack on and buil
 * libgranite-dev
 * libgtk-3-dev
 * libwebkit2gtk-4.0-dev
+* libdazzle-1.0-dev
 * meson
 * valac
 
 You can install them on elementary OS Juno with:
 
 ```shell
-sudo apt install elementary-sdk libwebkit2gtk-4.0-dev
+sudo apt install elementary-sdk libwebkit2gtk-4.0-dev libdazzle-1.0-dev
 ```
 
 Run `meson build` to configure the build environment and run `ninja` to build:

--- a/data/Application.css
+++ b/data/Application.css
@@ -172,3 +172,6 @@ checkbutton.menuitem check {
   margin-right: 1px;
 }
 
+dzlsuggestionpopover row {
+  padding: 5px;
+}

--- a/data/Application.css
+++ b/data/Application.css
@@ -175,3 +175,7 @@ checkbutton.menuitem check {
 dzlsuggestionpopover row {
   padding: 5px;
 }
+
+dzlsuggestionpopover row image {
+  -gtk-icon-palette: warning #fff;
+}

--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: x11
 Priority: extra
 Maintainer: Cassidy James Blaede <c@ssidyjam.es>
 Build-Depends: debhelper (>= 9),
+               libdazzle-1.0-dev,
                libgranite-dev,
                libgtk-3-dev,
                libwebkit2gtk-4.0-dev,

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,7 @@ executable(
         dependency('granite'),
         dependency('gtk+-3.0'),
         dependency('webkit2gtk-4.0'),
+        dependency('libdazzle-1.0')
     ],
     install: true
 )

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -17,9 +17,10 @@
 * Boston, MA 02110-1301 USA
 *
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
+*              Hannes Schulze <haschu0103@gmail.com>
 */
 
-public class UrlEntry : Gtk.Entry {
+public class UrlEntry : Dazzle.SuggestionEntry {
     private Gtk.ListStore list_store { get; set; }
     private Gtk.TreeIter iter { get; set; }
 

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -179,22 +179,15 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     }
 
     private async void filter_suggestions (string search) {
-        ThreadFunc<bool> run = () => {
-            var filtered_list_store = new ListStore (typeof (Dazzle.Suggestion));
-            for (int i = 0; i < list_store.get_n_items (); i++) {
-                var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
-                if (suggestion.id.contains (search) ||
-                    suggestion.title.contains (search)) {
-                    filtered_list_store.append (suggestion);
-                }
+        var filtered_list_store = new ListStore (typeof (Dazzle.Suggestion));
+        for (int i = 0; i < list_store.get_n_items (); i++) {
+            var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
+            if (suggestion.id.contains (search) ||
+                suggestion.title.contains (search)) {
+                filtered_list_store.append (suggestion);
             }
-            Idle.add(() => {
-                set_model (filtered_list_store);
-                return false;
-            });
-            return true;
-        };
-        new Thread<bool>("filter-suggestions-thread", run);
+        }
+        set_model (filtered_list_store);
     }
 
     private void add_suggestion (

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -205,12 +205,20 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         current_suggestion.icon_name = "system-search-symbolic";
         filtered_list_store.append (current_suggestion);
         if (!is_empty) {
+            Dazzle.Suggestion[] secondary_suggestions = { };
             for (int i = 0; i < list_store.get_n_items (); i++) {
                 var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
-                if (suggestion.id.contains (search) ||
-                    suggestion.title.contains (search)) {
+                if (Regex.match_simple ("^%s".printf (search), suggestion.id) ||
+                    Regex.match_simple ("^%s".printf (search), suggestion.title)) {
                     filtered_list_store.append (suggestion);
                 }
+                if (Regex.match_simple (".%s".printf (search), suggestion.id) ||
+                    Regex.match_simple (".%s".printf (search), suggestion.title)) {
+                    secondary_suggestions += suggestion;
+                }
+            }
+            foreach (var suggestion in secondary_suggestions) {
+                filtered_list_store.append (suggestion);
             }
         }
         set_model (filtered_list_store);

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -210,14 +210,15 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     private void add_suggestion (
       string domain,
       string? name = null,
-      string? reason = _("Popular website")
+      string? reason = _("Popular website"),
+      string? icon = "web-browser-symbolic"
     ) {
         debug ("Adding %s to suggestions…", domain);
 
         var suggestion = new Dazzle.Suggestion ();
         suggestion.id = domain;
         suggestion.title = domain;
-        suggestion.icon_name = "web-browser-symbolic";
+        suggestion.icon_name = icon;
 
         string description;
         if (name != null) {
@@ -242,7 +243,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         set_model (new ListStore (typeof (Dazzle.Suggestion)));
 
         foreach (var favorite in favorites) {
-            add_suggestion (favorite, null, _("Favorite website"));
+            add_suggestion (favorite, null, _("Favorite website"), "non-starred-symbolic");
         }
 
         add_suggestion ("247sports.com", "247Sports");

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -252,7 +252,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         set_model (new ListStore (typeof (Dazzle.Suggestion)));
 
         foreach (var favorite in favorites) {
-            add_suggestion (favorite, null, _("Favorite website"), "non-starred-symbolic");
+            add_suggestion (favorite, null, _("Favorite website"), "starred-symbolic");
         }
 
         add_suggestion ("247sports.com", "247Sports");

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -56,9 +56,13 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         });
 
         var changed_event = changed.connect (() => {
-            filter_suggestions.begin (text.strip (), (obj, res) => {
-                filter_suggestions.end(res);
-            });
+            if (text.length >= 2) {
+                filter_suggestions.begin (text.strip (), (obj, res) => {
+                    filter_suggestions.end(res);
+                });
+            } else {
+                set_model (new ListStore (typeof (Dazzle.Suggestion)));
+            }
         });
 
         activate_suggestion.connect (() => {

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -56,7 +56,6 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         });
 
         var changed_event = changed.connect (() => {
-            print ("test\n");
             filter_suggestions.begin (text.strip (), (obj, res) => {
                 filter_suggestions.end(res);
             });

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -21,8 +21,7 @@
 */
 
 public class UrlEntry : Dazzle.SuggestionEntry {
-    private Gtk.ListStore list_store { get; set; }
-    private Gtk.TreeIter iter { get; set; }
+    private ListStore list_store { get; set; }
 
     public WebKit.WebView web_view { get; construct set; }
 
@@ -35,7 +34,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     }
 
     construct {
-        tooltip_text = _("Enter a URL or search term");
+        var tooltip_text = _("Enter a URL or search term");
         placeholder_text = tooltip_text;
 
         tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, tooltip_text);
@@ -47,6 +46,14 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         var initial_favorites = Ephemeral.settings.get_strv ("favorite-websites");
         reset_suggestions (initial_favorites);
         set_secondary_icon ();
+
+        notify["text"].connect (() => {
+            if (text == "") {
+                placeholder_text = tooltip_text;
+            } else {
+                placeholder_text = null;
+            }
+        });
 
         activate.connect (() => {
             text = text.strip ();
@@ -66,6 +73,17 @@ public class UrlEntry : Dazzle.SuggestionEntry {
             }
             web_view.load_uri (text);
             web_view.grab_focus ();
+        });
+
+        suggestion_activated.connect (() => {
+            text = get_suggestion ().id;
+
+            activate ();
+        });
+
+        move_suggestion.connect (() => {
+            text = get_suggestion ().id;
+            set_position (-1);
         });
 
         focus_in_event.connect ((event) => {
@@ -140,8 +158,11 @@ public class UrlEntry : Dazzle.SuggestionEntry {
       string? reason = _("Popular website")
     ) {
         debug ("Adding %s to suggestions…", domain);
-        Gtk.TreeIter iter;
-        list_store.append (out iter);
+
+        var suggestion = new Dazzle.Suggestion ();
+        suggestion.id = domain;
+        suggestion.title = domain;
+        suggestion.icon_name = "web-browser-symbolic";
 
         string description;
         if (name != null) {
@@ -149,30 +170,21 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         } else {
              description = reason;
         }
+        suggestion.subtitle = description;
 
-        list_store.set (iter, 0, domain, 1, description);
+        list_store.append (suggestion);
     }
 
     private void reset_suggestions (string[] favorites = {}) {
         debug ("Resetting suggestions…");
 
-        if (list_store is Gtk.ListStore) {
-            list_store.clear ();
+        if (list_store is ListStore) {
+            list_store.remove_all ();
         }
 
-        list_store = new Gtk.ListStore (2, typeof (string), typeof (string));
+        list_store = new ListStore (typeof (Dazzle.Suggestion));
 
-        var completion = new Gtk.EntryCompletion ();
-        completion.inline_completion = true;
-        completion.minimum_key_length = 3;
-        completion.model = list_store;
-        completion.text_column = 0;
-
-        set_completion (completion);
-
-        var cell = new Gtk.CellRendererText ();
-        completion.pack_start (cell, false);
-        completion.add_attribute (cell, "text", 1);
+        set_model (list_store);
 
         foreach (var favorite in favorites) {
             add_suggestion (favorite, null, _("Favorite website"));
@@ -202,7 +214,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         add_suggestion ("appcenter.elementary.io", "elementary AppCenter");
         add_suggestion ("archive.org", "Internet Archive");
         add_suggestion ("arstechnica.com", "Ars Technica");
-        add_suggestion ("att.com", "AT&T");
+        add_suggestion ("att.com", "AT&amp;T");
         add_suggestion ("audible.com", "Audible");
         add_suggestion ("autotrader.com", "Autotrader");
         add_suggestion ("azlyrics.com", "AZLyrics");
@@ -211,20 +223,20 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         add_suggestion ("bankofamerica.com", "Bank of America");
         add_suggestion ("bankrate.com", "Bankrate");
         add_suggestion ("barclaycardus.com", "Barclays US");
-        add_suggestion ("barnesandnoble.com", "Barnes & Noble");
+        add_suggestion ("barnesandnoble.com", "Barnes &amp; Noble");
         add_suggestion ("bbc.com", "BBC");
         add_suggestion ("bbc.co.uk", "BBC");
-        add_suggestion ("bedbathandbeyond.com", "Bed Bath & Beyond");
+        add_suggestion ("bedbathandbeyond.com", "Bed Bath &amp; Beyond");
         add_suggestion ("bestbuy.com", "Best Buy");
         add_suggestion ("betanews.com", "BetaNews");
-        add_suggestion ("bhphotovideo.com", "B&H Photo");
+        add_suggestion ("bhphotovideo.com", "B&amp;H Photo");
         add_suggestion ("biblegateway.com", "BibleGateway.com");
         add_suggestion ("bing.com", "Bing");
         add_suggestion ("bizjournals.com", "The Business Journals");
         add_suggestion ("blogger.com", "Blogger");
         add_suggestion ("blogspot.com", "Blogspot");
         add_suggestion ("bloomberg.com", "Bloomberg");
-        add_suggestion ("bn.com", "Barnes & Noble");
+        add_suggestion ("bn.com", "Barnes &amp; Noble");
         add_suggestion ("bodybuilding.com", "Bodybuilding.com");
         add_suggestion ("booking.com", "Booking.com");
         add_suggestion ("box.com", "Box");
@@ -341,7 +353,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         add_suggestion ("harvard.edu", "Harvard University");
         add_suggestion ("healthcare.gov", "HealthCare.gov");
         add_suggestion ("hilton.com", "Hilton");
-        add_suggestion ("hm.com", "H&M");
+        add_suggestion ("hm.com", "H&amp;M");
         add_suggestion ("homedepot.com", "The Home Depot");
         add_suggestion ("hootsuite.com", "Hootsuite");
         add_suggestion ("hotels.com", "Hotels.com");
@@ -437,7 +449,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         add_suggestion ("nypost.com", "New York Post");
         add_suggestion ("nytimes.com", "New York Times");
         add_suggestion ("office365.com", "Office 365");
-        add_suggestion ("officedepot.com", "Office Depot & OfficeMax");
+        add_suggestion ("officedepot.com", "Office Depot &amp; OfficeMax");
         add_suggestion ("okcupid.com", "OKCupid");
         add_suggestion ("omgubuntu.co.uk", "OMG! Ubuntu!");
         add_suggestion ("opentable.com", "OpenTable");
@@ -565,7 +577,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         add_suggestion ("usatoday.com", "USA Today");
         add_suggestion ("usbank.com", "US Bank");
         add_suggestion ("usmagazine.com", "Us Weekly");
-        add_suggestion ("usnews.com", "US News & World Report");
+        add_suggestion ("usnews.com", "US News &amp; World Report");
         add_suggestion ("usps.com", "USPS");
         add_suggestion ("valadoc.org", "Valadoc");
         add_suggestion ("vanguard.com", "Vanguard");

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -175,15 +175,22 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     }
 
     private async void filter_suggestions (string search) {
-        var filtered_list_store = new ListStore (typeof (Dazzle.Suggestion));
-        for (int i = 0; i < list_store.get_n_items (); i++) {
-            var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
-            if (suggestion.id.contains (search) ||
-                suggestion.title.contains (search)) {
-                filtered_list_store.append (suggestion);
+        ThreadFunc<bool> run = () => {
+            var filtered_list_store = new ListStore (typeof (Dazzle.Suggestion));
+            for (int i = 0; i < list_store.get_n_items (); i++) {
+                var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
+                if (suggestion.id.contains (search) ||
+                    suggestion.title.contains (search)) {
+                    filtered_list_store.append (suggestion);
+                }
             }
-        }
-        set_model (filtered_list_store);
+            Idle.add(() => {
+                set_model (filtered_list_store);
+                return false;
+            });
+            return true;
+        };
+        new Thread<bool>("filter-suggestions-thread", run);
     }
 
     private void add_suggestion (

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -47,15 +47,13 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         reset_suggestions (initial_favorites);
         set_secondary_icon ();
 
-        notify["text"].connect (() => {
+        var changed_event = changed.connect (() => {
             if (text == "") {
                 placeholder_text = tooltip_text;
             } else {
                 placeholder_text = null;
             }
-        });
 
-        var changed_event = changed.connect (() => {
             if (text.length >= 2) {
                 filter_suggestions.begin (text.strip (), (obj, res) => {
                     filter_suggestions.end(res);
@@ -92,6 +90,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         });
 
         move_suggestion.connect ((amount) => {
+            // Workaround because suggestion_selected isn't available
             var current_index = 0;
             for (var i = 0; i < get_model ().get_n_items (); i++) {
                 var item = get_model ().get_item (i) as Dazzle.Suggestion;
@@ -106,6 +105,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                 new_item = get_suggestion ();
             }
 
+            // Update text to the selected domain name
             SignalHandler.block (this, changed_event);
             text = (new_item as Dazzle.Suggestion).id;
             SignalHandler.unblock (this, changed_event);

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -52,6 +52,10 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                 placeholder_text = tooltip_text;
             } else {
                 placeholder_text = null;
+
+                filter_suggestions.begin (text.strip (), (obj, res) => {
+                    filter_suggestions.end(res);
+                });
             }
         });
 
@@ -150,6 +154,18 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                 set_secondary_icon ();
             }
         });
+    }
+
+    private async void filter_suggestions (string search) {
+        var filtered_list_store = new ListStore (typeof (Dazzle.Suggestion));
+        for (int i = 0; i < list_store.get_n_items (); i++) {
+            var suggestion = list_store.get_item (i) as Dazzle.Suggestion;
+            if (suggestion.id.contains (search) ||
+                suggestion.title.contains (search)) {
+                filtered_list_store.append (suggestion);
+            }
+        }
+        set_model (filtered_list_store);
     }
 
     private void add_suggestion (

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -42,7 +42,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, tooltip_text);
 
         primary_icon_name = "system-search-symbolic";
-        primary_icon_tooltip_text = _("Enter a URL or search term");
+        primary_icon_tooltip_text = tooltip_text;
         primary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, primary_icon_tooltip_text);
 
         var initial_favorites = Ephemeral.settings.get_strv ("favorite-websites");
@@ -201,7 +201,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         string formatted_url;
         var is_url = format_url (search, out formatted_url);
         current_suggestion.id = search;
-        current_suggestion.title = (is_url ? "Go to \"%s\"" : "Search for \"%s\"").printf (search);
+        current_suggestion.title = (is_url ? _("Go to \"%s\"") : _("Search for \"%s\"")).printf (search);
         current_suggestion.icon_name = "system-search-symbolic";
         filtered_list_store.append (current_suggestion);
         if (!is_empty) {

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -201,7 +201,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         string formatted_url;
         var is_url = format_url (search, out formatted_url);
         current_suggestion.id = search;
-        current_suggestion.title = (is_url ? _("Go to \"%s\"") : _("Search for \"%s\"")).printf (search);
+        current_suggestion.title = (is_url ? _("Go to \"%s\"") : _("Search for \"%s\"")).printf (Markup.escape_text (search));
         current_suggestion.icon_name = "system-search-symbolic";
         filtered_list_store.append (current_suggestion);
         if (!is_empty) {

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -22,6 +22,7 @@
 
 public class UrlEntry : Dazzle.SuggestionEntry {
     private ListStore list_store { get; set; }
+    private string    last_text { get; set; }
 
     public WebKit.WebView web_view { get; construct set; }
 
@@ -61,6 +62,8 @@ public class UrlEntry : Dazzle.SuggestionEntry {
             } else {
                 set_model (new ListStore (typeof (Dazzle.Suggestion)));
             }
+
+            last_text = text;
         });
 
         activate_suggestion.connect (() => {
@@ -100,14 +103,23 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                 }
             }
 
-            var new_item = get_model ().get_item (current_index + amount);
-            if (new_item == null) {
-                new_item = get_suggestion ();
+            var new_index = current_index + amount;
+            var new_text = "";
+
+            if (new_index == -1) {
+                new_text = last_text;
+            } else {
+                var new_item = get_model ().get_item (new_index);
+                if (new_item == null) {
+                    new_item = get_suggestion ();
+                }
+
+                new_text = (new_item as Dazzle.Suggestion).id;
             }
 
             // Update text to the selected domain name
             SignalHandler.block (this, changed_event);
-            text = (new_item as Dazzle.Suggestion).id;
+            text = new_text;
             SignalHandler.unblock (this, changed_event);
             set_position (-1);
         });

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -37,6 +37,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     construct {
         var tooltip_text = _("Enter a URL or search term");
         placeholder_text = tooltip_text;
+        last_text = "";
 
         tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, tooltip_text);
 
@@ -114,7 +115,11 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                     new_item = get_suggestion ();
                 }
 
-                new_text = (new_item as Dazzle.Suggestion).id;
+                if (new_item is Dazzle.Suggestion) {
+                    new_text = (new_item as Dazzle.Suggestion).id;
+                } else {
+                    new_text = "";
+                }
             }
 
             // Update text to the selected domain name
@@ -234,7 +239,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
 
         list_store = new ListStore (typeof (Dazzle.Suggestion));
 
-        set_model (list_store);
+        set_model (new ListStore (typeof (Dazzle.Suggestion)));
 
         foreach (var favorite in favorites) {
             add_suggestion (favorite, null, _("Favorite website"));


### PR DESCRIPTION
Just a little experiment of mine, feel free to close this PR if you don't like it.

[Epiphany 3.32 now uses a Dazzle.SuggestionEntry](https://gitlab.gnome.org/GNOME/epiphany/commit/fccdc31d7b02dcb0c8c2f9aca86179694ab071dd), which adds support for some nice animations (and I think Ephemeral's current suggestions look a bit too static) :smile:

I only used `web-browser-symbolic` for icons (I don't want to download anything without the user's explicit permission), but I think this could be used to add different icons for popular sites and favorites (I haven't found one for popular sites yet) - and this could eventually even replace the "Popular site"-part in the subtitle.

**Still left TODO:**
- [x] You currently can't go back to the original text after selecting a suggestion
- [x] Different icons?
- [x] Figure out behaviour for the search suggestion-entry
- [x] Prioritize matches at the beginning of the string
- [x] Handle special characters

**Preview:**

![Preview](https://user-images.githubusercontent.com/43932053/56658917-213ba880-669c-11e9-9e71-3ff4cac4251f.gif)
