### PR TITLE
Namespacing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,20 +19,21 @@ executable(
     join_paths('src', 'Dialogs', 'ExternalDialog.vala'),
     join_paths('src', 'Dialogs', 'PreferencesDialog.vala'),
     join_paths('src', 'Dialogs', 'ScriptDialog.vala'),
+    join_paths('src', 'InfoBars', 'DefaultInfoBar.vala'),
+    join_paths('src', 'InfoBars', 'NativeInfoBar.vala'),
+    join_paths('src', 'InfoBars', 'NetworkInfoBar.vala'),
+    join_paths('src', 'InfoBars', 'PaidInfoBar.vala'),
     join_paths('src', 'Views', 'ErrorView.vala'),
     join_paths('src', 'Views', 'WelcomeView.vala'),
     join_paths('src', 'Widgets', 'BrowserButton.vala'),
-    join_paths('src', 'Widgets', 'DefaultInfoBar.vala'),
-    join_paths('src', 'Widgets', 'NativeInfoBar.vala'),
-    join_paths('src', 'Widgets', 'NetworkInfoBar.vala'),
-    join_paths('src', 'Widgets', 'PaidInfoBar.vala'),
     join_paths('src', 'Widgets', 'UrlEntry.vala'),
+    join_paths('src', 'Widgets', 'WebView.vala'),
     asresources,
     dependencies: [
         dependency('granite'),
         dependency('gtk+-3.0'),
+        dependency('libdazzle-1.0'),
         dependency('webkit2gtk-4.0'),
-        dependency('libdazzle-1.0')
     ],
     install: true
 )

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class Ephemeral : Gtk.Application {
+public class Ephemeral.Application : Gtk.Application {
     public const string[] CONTENT_TYPES = {
         "x-scheme-handler/http",
         "x-scheme-handler/https",
@@ -44,25 +44,25 @@ public class Ephemeral : Gtk.Application {
 
     private bool opening_link = false;
 
-    public Ephemeral () {
+    public Application () {
         Object (
             application_id: "com.github.cassidyjames.ephemeral",
             flags: ApplicationFlags.HANDLES_OPEN
         );
     }
 
-    public static Ephemeral _instance = null;
-    public static Ephemeral instance {
+    public static Application _instance = null;
+    public static Application instance {
         get {
             if (_instance == null) {
-                _instance = new Ephemeral ();
+                _instance = new Application ();
             }
             return _instance;
         }
     }
 
     static construct {
-        settings = new Settings (Ephemeral.instance.application_id);
+        settings = new Settings (Application.instance.application_id);
     }
 
     protected override void activate () {
@@ -105,7 +105,7 @@ public class Ephemeral : Gtk.Application {
     }
 
     public static int main (string[] args) {
-        var app = new Ephemeral ();
+        var app = new Application ();
         return app.run (args);
     }
 

--- a/src/Dialogs/CustomSearchDialog.vala
+++ b/src/Dialogs/CustomSearchDialog.vala
@@ -40,7 +40,7 @@ public class Ephemeral.CustomSearchDialog : Granite.MessageDialog {
 
         var search_entry = new Gtk.Entry ();
         search_entry.activates_default = true;
-        search_entry.text = Ephemeral.Application.settings.get_string ("search-engine");
+        search_entry.text = Application.settings.get_string ("search-engine");
         search_entry.bind_property ("text", accept, "sensitive", BindingFlags.SYNC_CREATE,
             (binding, srcval, ref targetval) => {
                 string text = (string) srcval;
@@ -61,7 +61,7 @@ public class Ephemeral.CustomSearchDialog : Granite.MessageDialog {
         set_default_response (Gtk.ResponseType.OK);
 
         accept.clicked.connect (() => {
-            Ephemeral.Application.settings.set_string ("search-engine", search_entry.text);
+            Application.settings.set_string ("search-engine", search_entry.text);
         });
     }
 }

--- a/src/Dialogs/CustomSearchDialog.vala
+++ b/src/Dialogs/CustomSearchDialog.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class CustomSearchDialog : Granite.MessageDialog {
+public class Ephemeral.CustomSearchDialog : Granite.MessageDialog {
     public CustomSearchDialog () {
         Object (
             image_icon: new ThemedIcon ("system-search"),
@@ -40,7 +40,7 @@ public class CustomSearchDialog : Granite.MessageDialog {
 
         var search_entry = new Gtk.Entry ();
         search_entry.activates_default = true;
-        search_entry.text = Ephemeral.settings.get_string ("search-engine");
+        search_entry.text = Ephemeral.Application.settings.get_string ("search-engine");
         search_entry.bind_property ("text", accept, "sensitive", BindingFlags.SYNC_CREATE,
             (binding, srcval, ref targetval) => {
                 string text = (string) srcval;
@@ -61,7 +61,7 @@ public class CustomSearchDialog : Granite.MessageDialog {
         set_default_response (Gtk.ResponseType.OK);
 
         accept.clicked.connect (() => {
-            Ephemeral.settings.set_string ("search-engine", search_entry.text);
+            Ephemeral.Application.settings.set_string ("search-engine", search_entry.text);
         });
     }
 }

--- a/src/Dialogs/ExternalDialog.vala
+++ b/src/Dialogs/ExternalDialog.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class ExternalDialog : Granite.MessageDialog {
+public class Ephemeral.ExternalDialog : Granite.MessageDialog {
     public string protocol { get; construct set; }
 
     public ExternalDialog (string? _protocol = null) {

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class PreferencesDialog : Granite.MessageDialog {
+public class Ephemeral.PreferencesDialog : Granite.MessageDialog {
     public PreferencesDialog () {
         Object (
             image_icon: new ThemedIcon ("document-open-recent"),

--- a/src/Dialogs/ScriptDialog.vala
+++ b/src/Dialogs/ScriptDialog.vala
@@ -19,7 +19,7 @@
 * Authored by: David Hewitt <davidmhewitt@gmail.com>
 */
 
-public class ScriptDialog : Granite.MessageDialog {
+public class Ephemeral.ScriptDialog : Granite.MessageDialog {
     public WebKit.ScriptDialog dialog_info { get; construct; }
 
     public ScriptDialog (WebKit.ScriptDialog dialog) {

--- a/src/Dialogs/ScriptDialog.vala
+++ b/src/Dialogs/ScriptDialog.vala
@@ -84,3 +84,4 @@ public class Ephemeral.ScriptDialog : Granite.MessageDialog {
         }
     }
 }
+

--- a/src/InfoBars/DefaultInfoBar.vala
+++ b/src/InfoBars/DefaultInfoBar.vala
@@ -40,7 +40,7 @@ public class Ephemeral.DefaultInfoBar : Gtk.InfoBar {
         default_label.use_markup = true;
         default_label.wrap = true;
 
-        var default_app_info = GLib.AppInfo.get_default_for_type (Ephemeral.Application.CONTENT_TYPES[0], false);
+        var default_app_info = GLib.AppInfo.get_default_for_type (Application.CONTENT_TYPES[0], false);
         var app_info = new GLib.DesktopAppInfo (GLib.Application.get_default ().application_id + ".desktop");
 
         var never_button = new Gtk.Button.with_label (_("Never Ask Again"));
@@ -53,15 +53,15 @@ public class Ephemeral.DefaultInfoBar : Gtk.InfoBar {
 
         revealed =
             !default_app_info.equal (app_info) &&
-            Ephemeral.Application.settings.get_boolean ("ask-default") &&
-            Ephemeral.Application.instance.ask_default_for_session;
+            Application.settings.get_boolean ("ask-default") &&
+            Application.instance.ask_default_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        for (int i = 0; i < Ephemeral.Application.CONTENT_TYPES.length; i++) {
-                            app_info.set_as_default_for_type (Ephemeral.Application.CONTENT_TYPES[i]);
+                        for (int i = 0; i < Application.CONTENT_TYPES.length; i++) {
+                            app_info.set_as_default_for_type (Application.CONTENT_TYPES[i]);
                         }
                     } catch (GLib.Error e) {
                         critical (e.message);
@@ -69,9 +69,9 @@ public class Ephemeral.DefaultInfoBar : Gtk.InfoBar {
                     revealed = false;
                     break;
                 case Gtk.ResponseType.REJECT:
-                    Ephemeral.Application.settings.set_boolean ("ask-default", false);
+                    Application.settings.set_boolean ("ask-default", false);
                 case Gtk.ResponseType.CLOSE:
-                    Ephemeral.Application.instance.ask_default_for_session = false;
+                    Application.instance.ask_default_for_session = false;
                     revealed = false;
                     break;
                 default:

--- a/src/InfoBars/DefaultInfoBar.vala
+++ b/src/InfoBars/DefaultInfoBar.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class DefaultInfoBar : Gtk.InfoBar {
+public class Ephemeral.DefaultInfoBar : Gtk.InfoBar {
     public DefaultInfoBar () {
         Object (
             message_type: Gtk.MessageType.QUESTION,
@@ -40,7 +40,7 @@ public class DefaultInfoBar : Gtk.InfoBar {
         default_label.use_markup = true;
         default_label.wrap = true;
 
-        var default_app_info = GLib.AppInfo.get_default_for_type (Ephemeral.CONTENT_TYPES[0], false);
+        var default_app_info = GLib.AppInfo.get_default_for_type (Ephemeral.Application.CONTENT_TYPES[0], false);
         var app_info = new GLib.DesktopAppInfo (GLib.Application.get_default ().application_id + ".desktop");
 
         var never_button = new Gtk.Button.with_label (_("Never Ask Again"));
@@ -53,15 +53,15 @@ public class DefaultInfoBar : Gtk.InfoBar {
 
         revealed =
             !default_app_info.equal (app_info) &&
-            Ephemeral.settings.get_boolean ("ask-default") &&
-            Ephemeral.instance.ask_default_for_session;
+            Ephemeral.Application.settings.get_boolean ("ask-default") &&
+            Ephemeral.Application.instance.ask_default_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        for (int i = 0; i < Ephemeral.CONTENT_TYPES.length; i++) {
-                            app_info.set_as_default_for_type (Ephemeral.CONTENT_TYPES[i]);
+                        for (int i = 0; i < Ephemeral.Application.CONTENT_TYPES.length; i++) {
+                            app_info.set_as_default_for_type (Ephemeral.Application.CONTENT_TYPES[i]);
                         }
                     } catch (GLib.Error e) {
                         critical (e.message);
@@ -69,9 +69,9 @@ public class DefaultInfoBar : Gtk.InfoBar {
                     revealed = false;
                     break;
                 case Gtk.ResponseType.REJECT:
-                    Ephemeral.settings.set_boolean ("ask-default", false);
+                    Ephemeral.Application.settings.set_boolean ("ask-default", false);
                 case Gtk.ResponseType.CLOSE:
-                    Ephemeral.instance.ask_default_for_session = false;
+                    Ephemeral.Application.instance.ask_default_for_session = false;
                     revealed = false;
                     break;
                 default:
@@ -80,3 +80,4 @@ public class DefaultInfoBar : Gtk.InfoBar {
         });
     }
 }
+

--- a/src/InfoBars/NativeInfoBar.vala
+++ b/src/InfoBars/NativeInfoBar.vala
@@ -44,7 +44,7 @@ public class Ephemeral.NativeInfoBar : Gtk.InfoBar {
 
         // TRANSLATORS: Includes an ellipsis (…) in English to signify the action will be performed in a new window
         var donate_button = new Gtk.Button.with_label (_("Donate…"));
-        donate_button.tooltip_text = Ephemeral.Application.DONATE_URL;
+        donate_button.tooltip_text = Application.DONATE_URL;
 
         get_content_area ().add (default_label);
         add_action_widget (dismiss_button, Gtk.ResponseType.REJECT);
@@ -53,23 +53,23 @@ public class Ephemeral.NativeInfoBar : Gtk.InfoBar {
         int64 now = new DateTime.now_utc ().to_unix ();
 
         revealed =
-            ! Ephemeral.Application.instance.native () &&
-            (Ephemeral.Application.settings.get_int64 ("last-native-response") < now - Ephemeral.Application.NOTICE_SECS) &&
-            Ephemeral.Application.instance.warn_native_for_session;
+            ! Application.instance.native () &&
+            (Application.settings.get_int64 ("last-native-response") < now - Application.NOTICE_SECS) &&
+            Application.instance.warn_native_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        Gtk.show_uri (get_screen (), Ephemeral.Application.DONATE_URL, Gtk.get_current_event_time ());
+                        Gtk.show_uri (get_screen (), Application.DONATE_URL, Gtk.get_current_event_time ());
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }
                 case Gtk.ResponseType.REJECT:
                     now = new DateTime.now_utc ().to_unix ();
-                    Ephemeral.Application.settings.set_int64 ("last-native-response", now);
+                    Application.settings.set_int64 ("last-native-response", now);
                 case Gtk.ResponseType.CLOSE:
-                    Ephemeral.Application.instance.warn_native_for_session = false;
+                    Application.instance.warn_native_for_session = false;
                     revealed = false;
                     break;
                 default:

--- a/src/InfoBars/NetworkInfoBar.vala
+++ b/src/InfoBars/NetworkInfoBar.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class NetworkInfoBar : Gtk.InfoBar {
+public class Ephemeral.NetworkInfoBar : Gtk.InfoBar {
     public NetworkInfoBar () {
         Object (
             message_type: Gtk.MessageType.WARNING,
@@ -56,7 +56,7 @@ public class NetworkInfoBar : Gtk.InfoBar {
                     }
                     break;
                 case Gtk.ResponseType.REJECT:
-                    Ephemeral.settings.set_boolean ("warn-network", false);
+                    Ephemeral.Application.settings.set_boolean ("warn-network", false);
                 case Gtk.ResponseType.CLOSE:
                     revealed = false;
                     break;
@@ -76,7 +76,8 @@ public class NetworkInfoBar : Gtk.InfoBar {
 
         revealed =
             reveal &&
-            Ephemeral.settings.get_boolean ("warn-network") &&
+            Ephemeral.Application.settings.get_boolean ("warn-network") &&
             !network_available;
     }
 }
+

--- a/src/InfoBars/NetworkInfoBar.vala
+++ b/src/InfoBars/NetworkInfoBar.vala
@@ -56,7 +56,7 @@ public class Ephemeral.NetworkInfoBar : Gtk.InfoBar {
                     }
                     break;
                 case Gtk.ResponseType.REJECT:
-                    Ephemeral.Application.settings.set_boolean ("warn-network", false);
+                    Application.settings.set_boolean ("warn-network", false);
                 case Gtk.ResponseType.CLOSE:
                     revealed = false;
                     break;
@@ -76,7 +76,7 @@ public class Ephemeral.NetworkInfoBar : Gtk.InfoBar {
 
         revealed =
             reveal &&
-            Ephemeral.Application.settings.get_boolean ("warn-network") &&
+            Application.settings.get_boolean ("warn-network") &&
             !network_available;
     }
 }

--- a/src/InfoBars/PaidInfoBar.vala
+++ b/src/InfoBars/PaidInfoBar.vala
@@ -19,8 +19,8 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class NativeInfoBar : Gtk.InfoBar {
-    public NativeInfoBar () {
+public class Ephemeral.PaidInfoBar : Gtk.InfoBar {
+    public PaidInfoBar () {
         Object (
             message_type: Gtk.MessageType.INFO,
             show_close_button: true
@@ -28,12 +28,14 @@ public class NativeInfoBar : Gtk.InfoBar {
     }
 
     construct {
-        string designed_for_elementary = _("Ephemeral is a paid app designed for elementary OS.");
-        string disclaimer = _("Some features may not work properly when running on another OS or desktop environment.");
-        string fund = _("Ephemeral is also typically funded by elementary AppCenter purchases. Consider donating if you find value in using Ephemeral on other platforms.");
+        // TRANSLATORS: This is an emphasized part at the beginning of a complete sentence, no terminating punctuation
+        string title = _("Ephemeral is a paid app");
+        // TRANSLATORS: This continues the previous string, with terminating punctuation
+        string details = _("funded by AppCenter purchases.");
+        string consider_purchasing = _("Consider purchasing or funding if you find value in using Ephemeral.");
 
         var default_label = new Gtk.Label ("<b>%s</b> %s\n<small>%s</small>".printf (
-            designed_for_elementary, disclaimer, fund
+            title, details, consider_purchasing
         ));
         default_label.use_markup = true;
         default_label.wrap = true;
@@ -42,34 +44,32 @@ public class NativeInfoBar : Gtk.InfoBar {
         dismiss_button.halign = Gtk.Align.END;
         dismiss_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
-        // TRANSLATORS: Includes an ellipsis (…) in English to signify the action will be performed in a new window
-        var donate_button = new Gtk.Button.with_label (_("Donate…"));
-        donate_button.tooltip_text = Ephemeral.DONATE_URL;
-
         get_content_area ().add (default_label);
         add_action_widget (dismiss_button, Gtk.ResponseType.REJECT);
-        add_action_widget (donate_button, Gtk.ResponseType.ACCEPT);
+        // TRANSLATORS: Includes an ellipsis (…) in English to signify the action will be performed in a new window
+        add_button (_("Purchase or Fund…"), Gtk.ResponseType.ACCEPT);
 
         int64 now = new DateTime.now_utc ().to_unix ();
 
         revealed =
-            ! Ephemeral.instance.native () &&
-            (Ephemeral.settings.get_int64 ("last-native-response") < now - Ephemeral.NOTICE_SECS) &&
-            Ephemeral.instance.warn_native_for_session;
+            Ephemeral.Application.instance.native () &&
+            ! paid () &&
+            (Ephemeral.Application.settings.get_int64 ("last-paid-response") < now - Ephemeral.Application.NOTICE_SECS) &&
+            Ephemeral.Application.instance.warn_paid_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        Gtk.show_uri (get_screen (), Ephemeral.DONATE_URL, Gtk.get_current_event_time ());
+                        Gtk.show_uri (get_screen (), "appstream://" + Ephemeral.Application.instance.application_id, Gtk.get_current_event_time ());
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }
                 case Gtk.ResponseType.REJECT:
                     now = new DateTime.now_utc ().to_unix ();
-                    Ephemeral.settings.set_int64 ("last-native-response", now);
+                    Ephemeral.Application.settings.set_int64 ("last-paid-response", now);
                 case Gtk.ResponseType.CLOSE:
-                    Ephemeral.instance.warn_native_for_session = false;
+                    Ephemeral.Application.instance.warn_paid_for_session = false;
                     revealed = false;
                     break;
                 default:
@@ -77,4 +77,17 @@ public class NativeInfoBar : Gtk.InfoBar {
             }
         });
     }
+
+    private bool paid () {
+        var appcenter_settings_schema = SettingsSchemaSource.get_default ().lookup ("io.elementary.appcenter.settings", false);
+        if (appcenter_settings_schema != null) {
+            if (appcenter_settings_schema.has_key ("paid-apps")) {
+                var appcenter_settings = new GLib.Settings ("io.elementary.appcenter.settings");
+                return strv_contains (appcenter_settings.get_strv ("paid-apps"), Ephemeral.Application.instance.application_id);
+            }
+        }
+
+        return false;
+    }
 }
+

--- a/src/InfoBars/PaidInfoBar.vala
+++ b/src/InfoBars/PaidInfoBar.vala
@@ -52,24 +52,24 @@ public class Ephemeral.PaidInfoBar : Gtk.InfoBar {
         int64 now = new DateTime.now_utc ().to_unix ();
 
         revealed =
-            Ephemeral.Application.instance.native () &&
+            Application.instance.native () &&
             ! paid () &&
-            (Ephemeral.Application.settings.get_int64 ("last-paid-response") < now - Ephemeral.Application.NOTICE_SECS) &&
-            Ephemeral.Application.instance.warn_paid_for_session;
+            (Application.settings.get_int64 ("last-paid-response") < now - Application.NOTICE_SECS) &&
+            Application.instance.warn_paid_for_session;
 
         response.connect ((response_id) => {
             switch (response_id) {
                 case Gtk.ResponseType.ACCEPT:
                     try {
-                        Gtk.show_uri (get_screen (), "appstream://" + Ephemeral.Application.instance.application_id, Gtk.get_current_event_time ());
+                        Gtk.show_uri (get_screen (), "appstream://" + Application.instance.application_id, Gtk.get_current_event_time ());
                     } catch (GLib.Error e) {
                         critical (e.message);
                     }
                 case Gtk.ResponseType.REJECT:
                     now = new DateTime.now_utc ().to_unix ();
-                    Ephemeral.Application.settings.set_int64 ("last-paid-response", now);
+                    Application.settings.set_int64 ("last-paid-response", now);
                 case Gtk.ResponseType.CLOSE:
-                    Ephemeral.Application.instance.warn_paid_for_session = false;
+                    Application.instance.warn_paid_for_session = false;
                     revealed = false;
                     break;
                 default:
@@ -83,7 +83,7 @@ public class Ephemeral.PaidInfoBar : Gtk.InfoBar {
         if (appcenter_settings_schema != null) {
             if (appcenter_settings_schema.has_key ("paid-apps")) {
                 var appcenter_settings = new GLib.Settings ("io.elementary.appcenter.settings");
-                return strv_contains (appcenter_settings.get_strv ("paid-apps"), Ephemeral.Application.instance.application_id);
+                return strv_contains (appcenter_settings.get_strv ("paid-apps"), Application.instance.application_id);
             }
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -19,28 +19,28 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class MainWindow : Gtk.Window {
+public class Ephemeral.MainWindow : Gtk.Window {
     public string uri { get; construct set; }
     public SimpleActionGroup actions { get; construct; }
     private Gtk.Button zoom_default_button;
 
     public Gtk.Stack stack { get; construct set; }
     // public WebKit.WebView web_view { get; construct set; }
-    public Ephemeral.WebView web_view { get; construct set; }
+    public WebView web_view { get; construct set; }
     public Gtk.Stack refresh_stop_stack { get; construct set; }
     public Gtk.Button back_button { get; construct set; }
     public Gtk.Button forward_button { get; construct set; }
     public Gtk.Button refresh_button { get; construct set; }
     public Gtk.Button stop_button { get; construct set; }
-    public Ephemeral.UrlEntry url_entry { get; construct set; }
-    public Ephemeral.BrowserButton browser_button { get; construct set; }
+    public UrlEntry url_entry { get; construct set; }
+    public BrowserButton browser_button { get; construct set; }
     public Gtk.Button erase_button { get; construct set; }
 
     public MainWindow (Gtk.Application application, string? _uri = null) {
         Object (
             application: application,
             border_width: 0,
-            icon_name: Ephemeral.Application.instance.application_id,
+            icon_name: Application.instance.application_id,
             resizable: true,
             title: "Ephemeral",
             uri: _uri,
@@ -56,7 +56,7 @@ public class MainWindow : Gtk.Window {
         header.show_close_button = true;
         header.has_subtitle = false;
 
-        web_view = new Ephemeral.WebView ();
+        web_view = new WebView ();
 
         back_button = new Gtk.Button.from_icon_name ("go-previous-symbolic", Gtk.IconSize.LARGE_TOOLBAR);
         back_button.sensitive = false;
@@ -80,14 +80,14 @@ public class MainWindow : Gtk.Window {
         refresh_stop_stack.add (stop_button);
         refresh_stop_stack.visible_child = refresh_button;
 
-        url_entry = new Ephemeral.UrlEntry (web_view);
+        url_entry = new UrlEntry (web_view);
 
         erase_button = new Gtk.Button.from_icon_name ("edit-delete", Gtk.IconSize.LARGE_TOOLBAR);
         erase_button.sensitive = false;
         erase_button.tooltip_text = _("Erase browsing history");
         erase_button.tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>W"}, erase_button.tooltip_text);
 
-        browser_button = new Ephemeral.BrowserButton (this, web_view);
+        browser_button = new BrowserButton (this, web_view);
         browser_button.sensitive = false;
 
         var settings_button = new Gtk.MenuButton ();
@@ -215,13 +215,13 @@ public class MainWindow : Gtk.Window {
 
         header.custom_title = url_entry;
 
-        var paid_info_bar = new Ephemeral.PaidInfoBar ();
-        var native_info_bar = new Ephemeral.NativeInfoBar ();
-        var default_info_bar = new Ephemeral.DefaultInfoBar ();
-        var network_info_bar = new Ephemeral.NetworkInfoBar ();
+        var paid_info_bar = new PaidInfoBar ();
+        var native_info_bar = new NativeInfoBar ();
+        var default_info_bar = new DefaultInfoBar ();
+        var network_info_bar = new NetworkInfoBar ();
 
-        var welcome_view = new Ephemeral.WelcomeView ();
-        var error_view = new Ephemeral.ErrorView ();
+        var welcome_view = new WelcomeView ();
+        var error_view = new ErrorView ();
 
         stack = new Gtk.Stack ();
         stack.transition_type = Gtk.StackTransitionType.CROSSFADE;
@@ -282,19 +282,19 @@ public class MainWindow : Gtk.Window {
 
         startpage_button.clicked.connect (() => {
             if (startpage_button.active) {
-                Ephemeral.Application.settings.set_string ("search-engine", Ephemeral.Application.STARTPAGE);
+                Application.settings.set_string ("search-engine", Application.STARTPAGE);
             }
         });
 
         ddg_button.clicked.connect (() => {
             if (ddg_button.active) {
-                Ephemeral.Application.settings.set_string ("search-engine", Ephemeral.Application.DDG);
+                Application.settings.set_string ("search-engine", Application.DDG);
             }
         });
 
         custom_search_button.clicked.connect (() => {
             if (custom_search_button.active) {
-                var custom_search_dialog = new Ephemeral.CustomSearchDialog ();
+                var custom_search_dialog = new CustomSearchDialog ();
                 custom_search_dialog.transient_for = (Gtk.Window) get_toplevel ();
 
                 custom_search_dialog.response.connect ((response_id) => {
@@ -319,15 +319,15 @@ public class MainWindow : Gtk.Window {
 
         preferences_button.clicked.connect (() => {
             settings_popover.popdown ();
-            var preferences_dialog = new Ephemeral.PreferencesDialog ();
+            var preferences_dialog = new PreferencesDialog ();
             preferences_dialog.transient_for = (Gtk.Window) get_toplevel ();
 
             preferences_dialog.response.connect ((response_id) => {
                 switch (response_id) {
                     case Gtk.ResponseType.OK:
-                        string[] keys = Ephemeral.Application.settings.list_keys ();
+                        string[] keys = Application.settings.list_keys ();
                         foreach (string key in keys) {
-                            Ephemeral.Application.settings.reset (key);
+                            Application.settings.reset (key);
                         }
 
                         set_search_engine_active (
@@ -408,8 +408,8 @@ public class MainWindow : Gtk.Window {
             return true;
         });
 
-        Ephemeral.Application.settings.bind ("zoom", web_view, "zoom-level", SettingsBindFlags.DEFAULT);
-        Ephemeral.Application.settings.bind_with_mapping ("zoom", zoom_default_button, "label", SettingsBindFlags.DEFAULT,
+        Application.settings.bind ("zoom", web_view, "zoom-level", SettingsBindFlags.DEFAULT);
+        Application.settings.bind_with_mapping ("zoom", zoom_default_button, "label", SettingsBindFlags.DEFAULT,
             (value, variant) => {
                 value.set_string ("%.0f%%".printf (variant.get_double () * 100));
                 return true;
@@ -536,18 +536,6 @@ public class MainWindow : Gtk.Window {
         );
 
         add_accel_group (accel_group);
-
-        web_view.button_release_event.connect ((event) => {
-            if (event.button == 8) {
-                web_view.go_back ();
-                return true;
-            } else if (event.button == 9) {
-                web_view.go_forward ();
-                return true;
-            }
-
-            return false;
-        });
     }
 
     private void update_progress () {
@@ -582,7 +570,7 @@ public class MainWindow : Gtk.Window {
 
     private void open_externally (string uri) {
         string protocol = uri.split ("://")[0];
-        var external_dialog = new Ephemeral.ExternalDialog (protocol);
+        var external_dialog = new ExternalDialog (protocol);
         external_dialog.transient_for = (Gtk.Window) get_toplevel ();
 
         external_dialog.response.connect ((response_id) => {
@@ -654,10 +642,10 @@ public class MainWindow : Gtk.Window {
         Gtk.RadioButton ddg_button,
         Gtk.RadioButton custom_search_button
     ) {
-        var search_engine = Ephemeral.Application.settings.get_string ("search-engine");
-        if (search_engine == Ephemeral.Application.STARTPAGE) {
+        var search_engine = Application.settings.get_string ("search-engine");
+        if (search_engine == Application.STARTPAGE) {
             startpage_button.active = true;
-        } else if (search_engine == Ephemeral.Application.DDG) {
+        } else if (search_engine == Application.DDG) {
             ddg_button.active = true;
         } else {
             custom_search_button.active = true;

--- a/src/Views/ErrorView.vala
+++ b/src/Views/ErrorView.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class ErrorView : Gtk.Grid {
+public class Ephemeral.ErrorView : Gtk.Grid {
     public ErrorView () {
         Object ();
     }

--- a/src/Views/WelcomeView.vala
+++ b/src/Views/WelcomeView.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class WelcomeView : Gtk.Grid {
+public class Ephemeral.WelcomeView : Gtk.Grid {
     public WelcomeView () {
         Object ();
     }

--- a/src/Widgets/BrowserButton.vala
+++ b/src/Widgets/BrowserButton.vala
@@ -19,7 +19,7 @@
 * Authored by: Cassidy James Blaede <c@ssidyjam.es>
 */
 
-public class BrowserButton : Gtk.Grid {
+public class Ephemeral.BrowserButton : Gtk.Grid {
     public Gtk.Window main_window { get; construct set; }
     public WebKit.WebView web_view { get; construct set; }
     public Gtk.MenuButton list_button {get; construct set; }
@@ -33,7 +33,7 @@ public class BrowserButton : Gtk.Grid {
     }
 
     construct {
-        List<AppInfo> external_apps = GLib.AppInfo.get_all_for_type (Ephemeral.CONTENT_TYPES[0]);
+        List<AppInfo> external_apps = GLib.AppInfo.get_all_for_type (Ephemeral.Application.CONTENT_TYPES[0]);
         foreach (AppInfo app_info in external_apps) {
             if (app_info.get_id () == GLib.Application.get_default ().application_id + ".desktop") {
                 external_apps.remove (app_info);
@@ -53,9 +53,9 @@ public class BrowserButton : Gtk.Grid {
             attach (list_button, 1, 0);
             var last_used_browser_shown = false;
 
-            if (Ephemeral.settings.get_string ("last-used-browser") != "") {
+            if (Ephemeral.Application.settings.get_string ("last-used-browser") != "") {
                 foreach (AppInfo app_info in external_apps) {
-                    if (app_info.get_id () == Ephemeral.settings.get_string ("last-used-browser")) {
+                    if (app_info.get_id () == Ephemeral.Application.settings.get_string ("last-used-browser")) {
                         var browser_icon = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
                         browser_icon.pixel_size = 24;
 
@@ -103,7 +103,7 @@ public class BrowserButton : Gtk.Grid {
             close_check.margin_bottom = 3;
             close_check.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
-            Ephemeral.settings.bind ("close-when-opening-externally", close_check, "active", SettingsBindFlags.DEFAULT);
+            Ephemeral.Application.settings.bind ("close-when-opening-externally", close_check, "active", SettingsBindFlags.DEFAULT);
 
             list_popover.add (list_grid);
 
@@ -126,7 +126,7 @@ public class BrowserButton : Gtk.Grid {
                 browser_item.visible = true;
 
                 browser_item.clicked.connect (() => {
-                    Ephemeral.settings.set_string ("last-used-browser", app_info.get_id ());
+                    Ephemeral.Application.settings.set_string ("last-used-browser", app_info.get_id ());
                     try_opening (app_info, web_view.get_uri ());
                     list_popover.popdown ();
                 });
@@ -142,8 +142,8 @@ public class BrowserButton : Gtk.Grid {
             list_grid.show_all ();
 
             // Update open_button when the gsettings value has changed
-            Ephemeral.settings.changed["last-used-browser"].connect (() => {
-                if (Ephemeral.settings.get_string ("last-used-browser") != "") {
+            Ephemeral.Application.settings.changed["last-used-browser"].connect (() => {
+                if (Ephemeral.Application.settings.get_string ("last-used-browser") != "") {
                     if (!last_used_browser_shown) {
                         // Add style classes if no browser has been used before
                         last_used_browser_shown = true;
@@ -167,7 +167,7 @@ public class BrowserButton : Gtk.Grid {
 
                     // Show the last-used browser
                     foreach (AppInfo app_info in external_apps) {
-                        if (app_info.get_id () == Ephemeral.settings.get_string ("last-used-browser")) {
+                        if (app_info.get_id () == Ephemeral.Application.settings.get_string ("last-used-browser")) {
                             var browser_icon = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
                             browser_icon.pixel_size = 24;
 
@@ -211,7 +211,7 @@ public class BrowserButton : Gtk.Grid {
                 add (open_single_browser_button);
 
                 open_single_browser_button.clicked.connect (() => {
-                    Ephemeral.settings.set_string ("last-used-browser", app_info.get_id ());
+                    Ephemeral.Application.settings.set_string ("last-used-browser", app_info.get_id ());
                     try_opening (app_info, web_view.get_uri ());
                 });
             }
@@ -224,7 +224,7 @@ public class BrowserButton : Gtk.Grid {
 
         try {
             app_info.launch_uris (uris, null);
-            if (Ephemeral.settings.get_boolean ("close-when-opening-externally")) {
+            if (Ephemeral.Application.settings.get_boolean ("close-when-opening-externally")) {
                 main_window.close ();
             }
         } catch (GLib.Error e) {

--- a/src/Widgets/BrowserButton.vala
+++ b/src/Widgets/BrowserButton.vala
@@ -33,7 +33,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
     }
 
     construct {
-        List<AppInfo> external_apps = GLib.AppInfo.get_all_for_type (Ephemeral.Application.CONTENT_TYPES[0]);
+        List<AppInfo> external_apps = GLib.AppInfo.get_all_for_type (Application.CONTENT_TYPES[0]);
         foreach (AppInfo app_info in external_apps) {
             if (app_info.get_id () == GLib.Application.get_default ().application_id + ".desktop") {
                 external_apps.remove (app_info);
@@ -53,9 +53,9 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
             attach (list_button, 1, 0);
             var last_used_browser_shown = false;
 
-            if (Ephemeral.Application.settings.get_string ("last-used-browser") != "") {
+            if (Application.settings.get_string ("last-used-browser") != "") {
                 foreach (AppInfo app_info in external_apps) {
-                    if (app_info.get_id () == Ephemeral.Application.settings.get_string ("last-used-browser")) {
+                    if (app_info.get_id () == Application.settings.get_string ("last-used-browser")) {
                         var browser_icon = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
                         browser_icon.pixel_size = 24;
 
@@ -103,7 +103,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
             close_check.margin_bottom = 3;
             close_check.get_style_context ().add_class (Gtk.STYLE_CLASS_MENUITEM);
 
-            Ephemeral.Application.settings.bind ("close-when-opening-externally", close_check, "active", SettingsBindFlags.DEFAULT);
+            Application.settings.bind ("close-when-opening-externally", close_check, "active", SettingsBindFlags.DEFAULT);
 
             list_popover.add (list_grid);
 
@@ -126,7 +126,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
                 browser_item.visible = true;
 
                 browser_item.clicked.connect (() => {
-                    Ephemeral.Application.settings.set_string ("last-used-browser", app_info.get_id ());
+                    Application.settings.set_string ("last-used-browser", app_info.get_id ());
                     try_opening (app_info, web_view.get_uri ());
                     list_popover.popdown ();
                 });
@@ -142,8 +142,8 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
             list_grid.show_all ();
 
             // Update open_button when the gsettings value has changed
-            Ephemeral.Application.settings.changed["last-used-browser"].connect (() => {
-                if (Ephemeral.Application.settings.get_string ("last-used-browser") != "") {
+            Application.settings.changed["last-used-browser"].connect (() => {
+                if (Application.settings.get_string ("last-used-browser") != "") {
                     if (!last_used_browser_shown) {
                         // Add style classes if no browser has been used before
                         last_used_browser_shown = true;
@@ -167,7 +167,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
 
                     // Show the last-used browser
                     foreach (AppInfo app_info in external_apps) {
-                        if (app_info.get_id () == Ephemeral.Application.settings.get_string ("last-used-browser")) {
+                        if (app_info.get_id () == Application.settings.get_string ("last-used-browser")) {
                             var browser_icon = new Gtk.Image.from_gicon (app_info.get_icon (), Gtk.IconSize.LARGE_TOOLBAR);
                             browser_icon.pixel_size = 24;
 
@@ -211,7 +211,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
                 add (open_single_browser_button);
 
                 open_single_browser_button.clicked.connect (() => {
-                    Ephemeral.Application.settings.set_string ("last-used-browser", app_info.get_id ());
+                    Application.settings.set_string ("last-used-browser", app_info.get_id ());
                     try_opening (app_info, web_view.get_uri ());
                 });
             }
@@ -224,7 +224,7 @@ public class Ephemeral.BrowserButton : Gtk.Grid {
 
         try {
             app_info.launch_uris (uris, null);
-            if (Ephemeral.Application.settings.get_boolean ("close-when-opening-externally")) {
+            if (Application.settings.get_boolean ("close-when-opening-externally")) {
                 main_window.close ();
             }
         } catch (GLib.Error e) {

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -20,7 +20,7 @@
 *              Hannes Schulze <haschu0103@gmail.com>
 */
 
-public class UrlEntry : Dazzle.SuggestionEntry {
+public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
     private ListStore list_store { get; set; }
     private string    last_text { get; set; }
 
@@ -45,7 +45,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
         primary_icon_tooltip_text = tooltip_text;
         primary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, primary_icon_tooltip_text);
 
-        var initial_favorites = Ephemeral.settings.get_strv ("favorite-websites");
+        var initial_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
         reset_suggestions (initial_favorites);
         set_secondary_icon ();
 
@@ -135,7 +135,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                 if (has_focus) {
                     activate ();
                 } else {
-                    var current_favorites = Ephemeral.settings.get_strv ("favorite-websites");
+                    var current_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
                     var uri = new Soup.URI (web_view.get_uri ());
 
                     if (uri != null) {
@@ -158,7 +158,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
                             reset_suggestions (current_favorites);
                         }
 
-                        Ephemeral.settings.set_strv ("favorite-websites", current_favorites);
+                        Ephemeral.Application.settings.set_strv ("favorite-websites", current_favorites);
                         set_secondary_icon ();
                     }
                 }
@@ -177,7 +177,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
     }
 
     private bool format_url (string input, out string formatted_url) {
-        var search_engine = Ephemeral.settings.get_string ("search-engine");
+        var search_engine = Ephemeral.Application.settings.get_string ("search-engine");
 
         // TODO: Better URL validation
         if (!input.contains ("://")) {
@@ -702,7 +702,7 @@ public class UrlEntry : Dazzle.SuggestionEntry {
             secondary_icon_tooltip_text = _("Go");
             secondary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"Return"}, secondary_icon_tooltip_text);
         } else {
-            var current_favorites = Ephemeral.settings.get_strv ("favorite-websites");
+            var current_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
             var uri = new Soup.URI (web_view.get_uri ());
 
             if (uri != null) {

--- a/src/Widgets/UrlEntry.vala
+++ b/src/Widgets/UrlEntry.vala
@@ -45,7 +45,7 @@ public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
         primary_icon_tooltip_text = tooltip_text;
         primary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>l"}, primary_icon_tooltip_text);
 
-        var initial_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
+        var initial_favorites = Application.settings.get_strv ("favorite-websites");
         reset_suggestions (initial_favorites);
         set_secondary_icon ();
 
@@ -135,7 +135,7 @@ public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
                 if (has_focus) {
                     activate ();
                 } else {
-                    var current_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
+                    var current_favorites = Application.settings.get_strv ("favorite-websites");
                     var uri = new Soup.URI (web_view.get_uri ());
 
                     if (uri != null) {
@@ -158,7 +158,7 @@ public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
                             reset_suggestions (current_favorites);
                         }
 
-                        Ephemeral.Application.settings.set_strv ("favorite-websites", current_favorites);
+                        Application.settings.set_strv ("favorite-websites", current_favorites);
                         set_secondary_icon ();
                     }
                 }
@@ -177,7 +177,7 @@ public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
     }
 
     private bool format_url (string input, out string formatted_url) {
-        var search_engine = Ephemeral.Application.settings.get_string ("search-engine");
+        var search_engine = Application.settings.get_string ("search-engine");
 
         // TODO: Better URL validation
         if (!input.contains ("://")) {
@@ -702,7 +702,7 @@ public class Ephemeral.UrlEntry : Dazzle.SuggestionEntry {
             secondary_icon_tooltip_text = _("Go");
             secondary_icon_tooltip_markup = Granite.markup_accel_tooltip ({"Return"}, secondary_icon_tooltip_text);
         } else {
-            var current_favorites = Ephemeral.Application.settings.get_strv ("favorite-websites");
+            var current_favorites = Application.settings.get_strv ("favorite-websites");
             var uri = new Soup.URI (web_view.get_uri ());
 
             if (uri != null) {

--- a/src/Widgets/WebView.vala
+++ b/src/Widgets/WebView.vala
@@ -1,0 +1,55 @@
+/*
+* Copyright © 2019 Cassidy James Blaede (https://cassidyjames.com)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Cassidy James Blaede <c@ssidyjam.es>
+*/
+
+public class Ephemeral.WebView : WebKit.WebView {
+    public WebView () {
+        Object (
+            expand: true,
+            height_request: 200
+        );
+    }
+
+    construct {
+        var webkit_settings = new WebKit.Settings();
+        webkit_settings.allow_file_access_from_file_urls = true;
+        webkit_settings.default_font_family = Gtk.Settings.get_default().gtk_font_name;
+        webkit_settings.enable_java = false;
+        webkit_settings.enable_mediasource = true;
+        webkit_settings.enable_plugins = false;
+        webkit_settings.enable_smooth_scrolling = true;
+
+        var webkit_web_context = new WebKit.WebContext.ephemeral ();
+        webkit_web_context.set_process_model (WebKit.ProcessModel.MULTIPLE_SECONDARY_PROCESSES);
+        webkit_web_context.get_cookie_manager ().set_accept_policy (WebKit.CookieAcceptPolicy.NO_THIRD_PARTY);
+
+        settings = webkit_settings;
+        web_context = webkit_web_context;
+
+        script_dialog.connect (on_script_dialog);
+    }
+
+    private bool on_script_dialog (WebKit.ScriptDialog dialog) {
+        var message_dialog = new Ephemeral.ScriptDialog (dialog);
+        message_dialog.show ();
+        return true;
+    }
+}
+

--- a/src/Widgets/WebView.vala
+++ b/src/Widgets/WebView.vala
@@ -44,10 +44,22 @@ public class Ephemeral.WebView : WebKit.WebView {
         web_context = webkit_web_context;
 
         script_dialog.connect (on_script_dialog);
+
+        button_release_event.connect ((event) => {
+            if (event.button == 8) {
+                go_back ();
+                return true;
+            } else if (event.button == 9) {
+                go_forward ();
+                return true;
+            }
+
+            return false;
+        });
     }
 
     private bool on_script_dialog (WebKit.ScriptDialog dialog) {
-        var message_dialog = new Ephemeral.ScriptDialog (dialog);
+        var message_dialog = new ScriptDialog (dialog);
         message_dialog.show ();
         return true;
     }


### PR DESCRIPTION
Wide-touching but functionally identical cleanup to make the codebase easier to work with.

- Namespaced all custom widgets under `Ephemeral.`
- Changed `Ephemeral` to `Ephemeral.Application`
- New `Ephemeral.WebView` that subclasses `WebKit.WebView`
- Moved `InfoBar`s to their own subdirectory