### PR TITLE
MainWindow: Support -dark themes

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -35,6 +35,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
     private UrlEntry url_entry;
     private BrowserButton browser_button;
     private Gtk.Button erase_button;
+    private Granite.ModeSwitch style_switch;
 
     private uint overlay_timeout_id = 0;
 
@@ -116,7 +117,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         var settings_popover = new Gtk.Popover (settings_button);
         settings_button.popover = settings_popover;
 
-        var style_switch = new Granite.ModeSwitch.from_icon_name (
+        style_switch = new Granite.ModeSwitch.from_icon_name (
             "display-brightness-symbolic",
             "weather-clear-night-symbolic"
         );
@@ -126,8 +127,8 @@ public class Ephemeral.MainWindow : Gtk.Window {
         style_switch.margin = 12;
         style_switch.margin_bottom = 6;
 
-        var gtk_settings = Gtk.Settings.get_default ();
-        style_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
+        // var gtk_settings = Gtk.Settings.get_default ();
+        // style_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
         Application.settings.bind ("dark-style", style_switch, "active", SettingsBindFlags.DEFAULT);
 
         var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
@@ -325,6 +326,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         set_titlebar (header);
         add (grid);
 
+        set_theme_variant ();
         show_all ();
 
         if (uri != null && uri != "") {
@@ -562,6 +564,8 @@ public class Ephemeral.MainWindow : Gtk.Window {
             }
         );
 
+        style_switch.notify["active"].connect (set_theme_variant);
+
         var accel_group = new Gtk.AccelGroup ();
 
         accel_group.connect (
@@ -739,6 +743,20 @@ public class Ephemeral.MainWindow : Gtk.Window {
         }
 
         return false;
+    }
+
+    private void set_theme_variant () {
+        var gtk_settings = Gtk.Settings.get_default ();
+        var theme_name = gtk_settings.gtk_theme_name;
+        if (theme_name.has_suffix ("-dark")) {
+            debug ("Dealing with a forced dark style, stripping `-dark` suffix…");
+            var light_theme_name = theme_name.replace ("-dark", "");
+            critical (light_theme_name);
+            gtk_settings.gtk_theme_name = light_theme_name;
+        } else {
+            debug ("Dealing with a normal style, requesting dark variant…");
+        }
+        Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = style_switch.active;
     }
 
     private void update_progress () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -747,9 +747,8 @@ public class Ephemeral.MainWindow : Gtk.Window {
         var gtk_settings = Gtk.Settings.get_default ();
         var theme_name = gtk_settings.gtk_theme_name;
         if (theme_name.has_suffix ("-dark")) {
-            debug ("Dealing with a forced dark style, stripping `-dark` suffix…");
             var light_theme_name = theme_name.replace ("-dark", "");
-            critical (light_theme_name);
+            debug ("Dealing with a forced dark style, stripping `-dark` suffix to set `%s`…", light_theme_name);
             gtk_settings.gtk_theme_name = light_theme_name;
         } else {
             debug ("Dealing with a normal style, requesting dark variant…");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -36,6 +36,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
     private BrowserButton browser_button;
     private Gtk.Button erase_button;
     private Granite.ModeSwitch style_switch;
+    private Gtk.Settings gtk_settings;
 
     private uint overlay_timeout_id = 0;
 
@@ -52,6 +53,8 @@ public class Ephemeral.MainWindow : Gtk.Window {
     }
 
     construct {
+        gtk_settings = Gtk.Settings.get_default ();
+
         default_height = 800;
         default_width = 1280;
 
@@ -563,6 +566,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         );
 
         style_switch.notify["active"].connect (set_theme_variant);
+        gtk_settings.notify["gtk-theme-name"].connect (set_theme_variant);
 
         var accel_group = new Gtk.AccelGroup ();
 
@@ -744,7 +748,6 @@ public class Ephemeral.MainWindow : Gtk.Window {
     }
 
     private void set_theme_variant () {
-        var gtk_settings = Gtk.Settings.get_default ();
         var theme_name = gtk_settings.gtk_theme_name;
         if (theme_name.has_suffix ("-dark")) {
             var light_theme_name = theme_name.replace ("-dark", "");
@@ -753,7 +756,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         } else {
             debug ("Dealing with a normal style, requesting dark variant…");
         }
-        Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = style_switch.active;
+        gtk_settings.gtk_application_prefer_dark_theme = style_switch.active;
     }
 
     private void update_progress () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -127,8 +127,6 @@ public class Ephemeral.MainWindow : Gtk.Window {
         style_switch.margin = 12;
         style_switch.margin_bottom = 6;
 
-        // var gtk_settings = Gtk.Settings.get_default ();
-        // style_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
         Application.settings.bind ("dark-style", style_switch, "active", SettingsBindFlags.DEFAULT);
 
         var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);


### PR DESCRIPTION
Should work better with `-dark` forced themes, like on Ubuntu or GNOME (with Tweaks). Kinda a major hack.