### PR TITLE
MainWindow: Hide style_switch when using hacky -dark theme

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -130,6 +130,10 @@ public class Ephemeral.MainWindow : Gtk.Window {
         style_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
         Application.settings.bind ("dark-style", style_switch, "active", SettingsBindFlags.DEFAULT);
 
+        var style_switch_revealer = new Gtk.Revealer ();
+        style_switch_revealer.add (style_switch);
+        style_switch_revealer.reveal_child = !gtk_settings.gtk_theme_name.has_suffix ("-dark");
+
         var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
         zoom_out_button.tooltip_markup = Granite.markup_accel_tooltip (
             {"<Ctrl>minus"},
@@ -262,7 +266,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         settings_popover_grid.orientation = Gtk.Orientation.VERTICAL;
         settings_popover_grid.width_request = 200;
 
-        settings_popover_grid.add (style_switch);
+        settings_popover_grid.add (style_switch_revealer);
         settings_popover_grid.add (zoom_grid);
         settings_popover_grid.add (js_button);
         settings_popover_grid.add (new MenuSeparator ());

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -132,6 +132,12 @@ public class Ephemeral.MainWindow : Gtk.Window {
 
         var style_switch_revealer = new Gtk.Revealer ();
         style_switch_revealer.add (style_switch);
+
+        // WebKit uses -dark to set a dark style, and some OSes expose -dark
+        // stylesheets to users has a hacky dark mode (like Ubuntu and Pop!_OS).
+        // As such, if the OS or user is forcing a -dark stylesheet, just take
+        // away the style switch. This is probably similar to how I'd treat a
+        // real dark mode, anyway.
         style_switch_revealer.reveal_child = !gtk_settings.gtk_theme_name.has_suffix ("-dark");
 
         var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -51,6 +51,8 @@ public class Ephemeral.MainWindow : Gtk.Window {
     }
 
     construct {
+        var gtk_settings = Gtk.Settings.get_default ();
+        
         default_height = 800;
         default_width = 1280;
 
@@ -126,7 +128,6 @@ public class Ephemeral.MainWindow : Gtk.Window {
         style_switch.margin = 12;
         style_switch.margin_bottom = 6;
 
-        var gtk_settings = Gtk.Settings.get_default ();
         style_switch.bind_property ("active", gtk_settings, "gtk_application_prefer_dark_theme");
         Application.settings.bind ("dark-style", style_switch, "active", SettingsBindFlags.DEFAULT);
 
@@ -138,7 +139,14 @@ public class Ephemeral.MainWindow : Gtk.Window {
         // As such, if the OS or user is forcing a -dark stylesheet, just take
         // away the style switch. This is probably similar to how I'd treat a
         // real dark mode, anyway.
-        style_switch_revealer.reveal_child = !gtk_settings.gtk_theme_name.has_suffix ("-dark");
+        gtk_settings.bind_property ("gtk-theme-name", style_switch_revealer, "reveal-child",
+            BindingFlags.SYNC_CREATE,
+            (binding, srcval, ref targetval) => {
+                string gtk_theme_name = (string) srcval;
+                targetval.set_boolean (!gtk_theme_name.has_suffix ("-dark"));
+                return true;
+            }
+        );
 
         var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
         zoom_out_button.tooltip_markup = Granite.markup_accel_tooltip (
@@ -446,7 +454,6 @@ public class Ephemeral.MainWindow : Gtk.Window {
             preferences_dialog.run ();
             preferences_dialog.destroy ();
         });
-
 
         web_view.load_changed.connect (update_progress);
         web_view.notify["uri"].connect (update_progress);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -134,7 +134,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
         style_switch_revealer.add (style_switch);
 
         // WebKit uses -dark to set a dark style, and some OSes expose -dark
-        // stylesheets to users has a hacky dark mode (like Ubuntu and Pop!_OS).
+        // stylesheets to users as a hacky dark mode (like Ubuntu and Pop!_OS).
         // As such, if the OS or user is forcing a -dark stylesheet, just take
         // away the style switch. This is probably similar to how I'd treat a
         // real dark mode, anyway.

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -52,7 +52,7 @@ public class Ephemeral.MainWindow : Gtk.Window {
 
     construct {
         var gtk_settings = Gtk.Settings.get_default ();
-        
+
         default_height = 800;
         default_width = 1280;
 

--- a/src/Widgets/WebView.vala
+++ b/src/Widgets/WebView.vala
@@ -23,8 +23,7 @@ public class Ephemeral.WebView : WebKit.WebView {
     public WebView () {
         Object (
             expand: true,
-            height_request: 200,
-            user_content_manager: new WebKit.UserContentManager ()
+            height_request: 200
         );
     }
 
@@ -37,27 +36,6 @@ public class Ephemeral.WebView : WebKit.WebView {
         webkit_settings.enable_mediasource = true;
         webkit_settings.enable_plugins = false;
         webkit_settings.enable_smooth_scrolling = true;
-
-// FIXME: Working around https://bugs.webkit.org/show_bug.cgi?id=197947
-        var undark_css = new WebKit.UserStyleSheet (
-            """
-            body,
-            button,
-            input,
-            select,
-            textarea,
-            ::-webkit-file-upload-button {
-                background: white;
-                color: black;
-            }
-            """,
-            WebKit.UserContentInjectedFrames.ALL_FRAMES,
-            WebKit.UserStyleLevel.AUTHOR,
-            null,
-            null
-        );
-        user_content_manager.add_style_sheet (undark_css);
-// ENDFIXME
 
         var webkit_web_context = new WebKit.WebContext.ephemeral ();
         webkit_web_context.set_process_model (WebKit.ProcessModel.MULTIPLE_SECONDARY_PROCESSES);


### PR DESCRIPTION
Alternative to #233. Fixes #231 