### PR TITLE
Open from clipboard

### DIFF
--- a/data/launcher.desktop.in
+++ b/data/launcher.desktop.in
@@ -10,12 +10,12 @@ Type=Application
 X-GNOME-Gettext-Domain=com.github.cassidyjames.ephemeral
 Keywords=WWW;web;browser;internet;private;incognito;focus;temporary;cookies;
 MimeType=x-scheme-handler/http;x-scheme-handler/https;text/html;application/xhtml+xml;application/x-extension-htm;application/x-extension-html;application/x-extension-shtml;application/x-extension-xht;application/x-extension-mhtml;
-Actions=New;Open From Clipboard;
+Actions=New;Clipboard;
 
 [Desktop Action New]
 Name=New Window
 Exec=com.github.cassidyjames.ephemeral
 
-[Desktop Action Open From Clipboard]
-Name=Open From Clipboard
-Exec=com.github.cassidyjames.ephemeral --open-from-clipboard
+[Desktop Action Clipboard]
+Name=Open from Clipboard
+Exec=com.github.cassidyjames.ephemeral --clipboard

--- a/data/launcher.desktop.in
+++ b/data/launcher.desktop.in
@@ -10,8 +10,12 @@ Type=Application
 X-GNOME-Gettext-Domain=com.github.cassidyjames.ephemeral
 Keywords=WWW;web;browser;internet;private;incognito;focus;temporary;cookies;
 MimeType=x-scheme-handler/http;x-scheme-handler/https;text/html;application/xhtml+xml;application/x-extension-htm;application/x-extension-html;application/x-extension-shtml;application/x-extension-xht;application/x-extension-mhtml;
-Actions=New;
+Actions=New;Open From Clipboard;
 
 [Desktop Action New]
 Name=New Window
 Exec=com.github.cassidyjames.ephemeral
+
+[Desktop Action Open From Clipboard]
+Name=Open From Clipboard
+Exec=com.github.cassidyjames.ephemeral --open-from-clipboard

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -48,10 +48,18 @@ public class Ephemeral.Application : Gtk.Application {
 
     private bool opening_link = false;
 
+    private static bool open_from_clipboard = false;
+
+    private const OptionEntry[] OPTIONS = {
+        { "open-from-clipboard", 'c', 0, OptionArg.NONE, ref open_from_clipboard,
+            "Open links from clipboard" },
+        { null }
+    };
+
     public Application () {
         Object (
             application_id: "com.github.cassidyjames.ephemeral",
-            flags: ApplicationFlags.HANDLES_OPEN
+            flags: ApplicationFlags.HANDLES_OPEN | ApplicationFlags.HANDLES_COMMAND_LINE
         );
     }
 
@@ -154,6 +162,51 @@ public class Ephemeral.Application : Gtk.Application {
                 app_window.show_all ();
             }
         }
+    }
+
+    public override int command_line (ApplicationCommandLine command_line) {
+        this.hold ();
+
+        int res = handle_command_line (command_line);
+
+        this.release ();
+        return res;
+    }
+
+    private int handle_command_line (ApplicationCommandLine command_line) {
+        string[] args = command_line.get_arguments ();
+
+        if (args.length == 1) {
+            args = { args[0], "." };
+        }
+
+        unowned string[] tmp = args;
+
+        try {
+            var option_context = new OptionContext ();
+            option_context.set_help_enabled (true);
+            option_context.add_main_entries (OPTIONS, null);
+
+            option_context.parse (ref tmp);
+        } catch (OptionError e) {
+            command_line.print (_("Error: %s") + "\n", e.message);
+            command_line.print (_("Run '%s --help' to see a full list of available options.") + "\n", args[0]);
+            return 1;
+        }
+
+        if (open_from_clipboard) {
+            var display = Gdk.Display.get_default ();
+            var clipboard = Gtk.Clipboard.get_default (display);
+
+            var uri = clipboard.wait_for_text ();
+            if (uri != null) {
+                open ({File.new_for_uri (uri)}, "");
+            }
+        } else {
+            activate ();
+        }
+
+        return 0;
     }
 
     public static int main (string[] args) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -51,7 +51,7 @@ public class Ephemeral.Application : Gtk.Application {
     private static bool open_from_clipboard = false;
 
     private const OptionEntry[] OPTIONS = {
-        { "open-from-clipboard", 'c', 0, OptionArg.NONE, ref open_from_clipboard,
+        { "clipboard", 'c', 0, OptionArg.NONE, ref open_from_clipboard,
             "Open links from clipboard" },
         { null }
     };

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -199,9 +199,7 @@ public class Ephemeral.Application : Gtk.Application {
             var clipboard = Gtk.Clipboard.get_default (display);
 
             var uri = clipboard.wait_for_text ();
-            if (uri != null) {
-                open ({File.new_for_uri (uri)}, "");
-            }
+            open ({File.new_for_uri (uri)}, "");
         } else {
             activate ();
         }


### PR DESCRIPTION
Sometimes I copy a link to the clipboard because it is not recognized as a link in the application. This pull request adds the action to open a link from the clipboard.

https://user-images.githubusercontent.com/10796736/110685942-18e0ae00-81df-11eb-909d-74e5c25310c0.mp4